### PR TITLE
Fixed broken unsubscribe.

### DIFF
--- a/src/record/record.js
+++ b/src/record/record.js
@@ -215,7 +215,7 @@ Record.prototype.unsubscribe = function( pathOrCallback, callback ) {
 		return;
 	}
 	if (arguments.length === 2) {
-		this._eventEmitter.off( pathOrCallback, callcallbackback );
+		this._eventEmitter.off( pathOrCallback, callback );
 	} else {
 		this._eventEmitter.off( ALL_EVENT, pathOrCallback );
 	}

--- a/src/record/record.js
+++ b/src/record/record.js
@@ -214,8 +214,11 @@ Record.prototype.unsubscribe = function( pathOrCallback, callback ) {
 	if( this._checkDestroyed( 'unsubscribe' ) ) {
 		return;
 	}
-	var event = arguments.length === 2 ? pathOrCallback : ALL_EVENT;
-	this._eventEmitter.off( event, callback );
+	if (arguments.length === 2) {
+		this._eventEmitter.off( pathOrCallback, callcallbackback );
+	} else {
+		this._eventEmitter.off( ALL_EVENT, pathOrCallback );
+	}
 };
 
 /**


### PR DESCRIPTION
This fixes an issue where `unsubscribe(callback)` would unsubscribe **all** callbacks instead of just the one provided.