### PR TITLE
record: Always call whenReady asynchronously. Fixes #204

### DIFF
--- a/src/record/record.js
+++ b/src/record/record.js
@@ -272,7 +272,7 @@ Record.prototype.delete = function() {
  */
 Record.prototype.whenReady = function( callback ) {
 	if( this.isReady === true ) {
-		setTimeout( callback.bind( null, this ), 0 );
+		setTimeout( callback.bind( this, this ), 0 );
 	} else {
 		this.once( 'ready', callback.bind( this, this ) );
 	}

--- a/src/record/record.js
+++ b/src/record/record.js
@@ -272,7 +272,7 @@ Record.prototype.delete = function() {
  */
 Record.prototype.whenReady = function( callback ) {
 	if( this.isReady === true ) {
-		callback( this );
+		setTimeout( callback.bind( null, this ), 0 );
 	} else {
 		this.once( 'ready', callback.bind( this, this ) );
 	}


### PR DESCRIPTION
I'm not sure why this is required. But without this weird stuff happens. See #204.