### PR TITLE
Fix record discard/delete & subscribe race

### DIFF
--- a/src/record/record.js
+++ b/src/record/record.js
@@ -632,9 +632,9 @@ Record.prototype._onTimeout = function( timeoutType ) {
 		this._sendRead();
 	}
 	else {
-  	this._clearTimeouts();
+		this._clearTimeouts();
 		this.isDestroyed = true;
-	 	this._eventEmitter.off();
+		this._eventEmitter.off();
 		this._resubscribeNotifier.destroy();
 	 	this._client = null;
 		this._eventEmitter = null;

--- a/src/record/record.js
+++ b/src/record/record.js
@@ -628,11 +628,11 @@ Record.prototype._onTimeout = function( timeoutType ) {
  * @returns {void}
  */
  Record.prototype._destroy = function() {
+	this._clearTimeouts();
 	if (this.usages > 0) {
 		this._sendRead();
 	}
 	else {
-		this._clearTimeouts();
 		this.isDestroyed = true;
 		this._eventEmitter.off();
 		this._resubscribeNotifier.destroy();

--- a/src/record/record.js
+++ b/src/record/record.js
@@ -249,7 +249,7 @@ Record.prototype.discard = function() {
 			this._connection.sendMsg( C.TOPIC.RECORD, C.ACTIONS.UNSUBSCRIBE, [ this.name ] );
 			this._resubscribeNotifier.destroy();
 		}
-	}.bind(this) );
+	}.bind( this ) );
 };
 
 /**
@@ -268,7 +268,7 @@ Record.prototype.delete = function() {
 		this._deleteAckTimeout = setTimeout( this._onTimeout.bind( this, C.EVENT.DELETE_TIMEOUT ), this._options.recordDeleteTimeout );
 		this._connection.sendMsg( C.TOPIC.RECORD, C.ACTIONS.DELETE, [ this.name ] );
 		this._resubscribeNotifier.destroy();
-	}.bind(this) );
+	}.bind( this ) );
 
 };
 

--- a/src/record/record.js
+++ b/src/record/record.js
@@ -371,6 +371,7 @@ Record.prototype._processAckMessage = function( message ) {
 	}
 
 	else if( acknowledgedAction === C.ACTIONS.DELETE ) {
+		this.usages = 0;
 		this.emit( 'delete' );
 		this._destroy();
 	}

--- a/src/record/record.js
+++ b/src/record/record.js
@@ -42,10 +42,7 @@ var Record = function( name, recordOptions, connection, options, client ) {
 	if( options.mergeStrategy ) {
 		this.setMergeStrategy( options.mergeStrategy );
 	}
-	this._resubscribeNotifier = new ResubscribeNotifier( this._client, this._sendRead.bind( this ) );
-	this._readAckTimeout = setTimeout( this._onTimeout.bind( this, C.EVENT.ACK_TIMEOUT ), this._options.recordReadAckTimeout );
-	this._readTimeout = setTimeout( this._onTimeout.bind( this, C.EVENT.RESPONSE_TIMEOUT ), this._options.recordReadTimeout );
-	this._sendRead();
+	this._resubscribeNotifier = new ResubscribeNotifier( this._client, this._sendRead.bind( this ), this._clearTimeouts.bind( this ), true );
 };
 
 EventEmitter( Record.prototype );
@@ -468,7 +465,9 @@ Record.prototype._setReady = function() {
  * @returns {void}
  */
  Record.prototype._sendRead = function() {
- 	this._connection.sendMsg( C.TOPIC.RECORD, C.ACTIONS.CREATEORREAD, [ this.name ] );
+	 this._readAckTimeout = setTimeout( this._onTimeout.bind( this, C.EVENT.ACK_TIMEOUT ), this._options.recordReadAckTimeout );
+	 this._readTimeout = setTimeout( this._onTimeout.bind( this, C.EVENT.RESPONSE_TIMEOUT ), this._options.recordReadTimeout );
+	 this._connection.sendMsg( C.TOPIC.RECORD, C.ACTIONS.CREATEORREAD, [ this.name ] );
  };
 
 

--- a/test-unit/unit/record/record-handler-listSpec.js
+++ b/test-unit/unit/record/record-handler-listSpec.js
@@ -29,7 +29,7 @@ describe( 'record handler returns the right list', function(){
 
 	it( 'retrieves listA again', function() {
 		connection.lastSendMessage = null;
-		
+
 		listA2 = recordHandler.getList( 'listA' );
 		expect( listA ).toBe( listA2 );
 
@@ -55,12 +55,6 @@ describe( 'record handler returns the right list', function(){
 		expect( connection.lastSendMessage ).toBe( msg( 'R|US|listA+' ) );
 	});
 
-	it( 'returns a new listA and resubscribes', function(){
-		expect( recordHandler.getList( 'listA' ) ).not.toBe( listA );
-		expect( listA.isDestroyed ).toBe( false );
-		expect( connection.lastSendMessage ).toBe( msg( 'R|CR|listA+' ) );
-	});
-
 	it( 'has destroyed listA when discard ack is received', function(){
 		recordHandler._$handle({
 			topic: 'R',
@@ -69,5 +63,12 @@ describe( 'record handler returns the right list', function(){
 		});
 		expect( onDiscard ).toHaveBeenCalled();
 		expect( listA.isDestroyed ).toBe( true );
+	});
+
+	it( 'returns a new listA and resubscribes', function(){
+		var listA2 = recordHandler.getList( 'listA' )
+		expect( listA2 ).not.toBe( listA );
+		expect( listA2.isDestroyed ).toBe( false );
+		expect( connection.lastSendMessage ).toBe( msg( 'R|CR|listA+' ) );
 	});
 });

--- a/test-unit/unit/record/record-handler-recordSpec.js
+++ b/test-unit/unit/record/record-handler-recordSpec.js
@@ -42,12 +42,6 @@ describe( 'record handler returns the right records', function(){
 		expect( connection.lastSendMessage ).toBe( msg( 'R|US|recordA+' ) );
 	});
 
-	it( 'returns a new recordA and resubscribes', function(){
-		expect( recordHandler.getRecord( 'recordA' ) ).not.toBe( recordA );
-		expect( recordA.isDestroyed ).toBe( false );
-		expect( connection.lastSendMessage ).toBe( msg( 'R|CR|recordA+' ) );
-	});
-
 	it( 'has destroyed record A when discard ack is received', function(){
 		recordHandler._$handle({
 			topic: 'R',
@@ -56,6 +50,13 @@ describe( 'record handler returns the right records', function(){
 		});
 		expect( onDiscard ).toHaveBeenCalled();
 		expect( recordA.isDestroyed ).toBe( true );
+	});
+
+	it( 'returns a new recordA and resubscribes', function(){
+		var recordA2 = recordHandler.getRecord( 'recordA' )
+		expect( recordA2 ).not.toBe( recordA );
+		expect( recordA2.isDestroyed ).toBe( false );
+		expect( connection.lastSendMessage ).toBe( msg( 'R|CR|recordA+' ) );
 	});
 });
 


### PR DESCRIPTION
This is my try at fixing the discard/delete and subscribe data-races. https://github.com/deepstreamIO/deepstream.io-client-js/issues/204

The basic idea is that the record can revive itself AFTER successful discard/delete, using the pending queue for the time between re-subscription and revival.

This ensures that there CAN BE ONLY ONE active record instance for the client avoiding the:

```
UNSOLICITED_MESSAGE
UNSOLICITED_MESSAGE
ACK_TIMEOUT
RESPONSE_TIMEOUT
MULTIPLE_SUBSCRIBTIONS
```

error cycle
