### PR TITLE
Record/patch

### DIFF
--- a/src/default-options.js
+++ b/src/default-options.js
@@ -194,7 +194,5 @@ module.exports = {
 	 */
 	mergeStrategy: MERGE_STRATEGIES.REMOTE_WINS,
 
-	recordDeepCopy: true,
-
-	recordDeepCompare: true
+	recordDeepCopy: true
 };

--- a/src/default-options.js
+++ b/src/default-options.js
@@ -192,5 +192,9 @@ module.exports = {
 	 *                                   returned data as the latest revision. This can be overriden on a per record
 	 *                                   basis by setting the `setMergeStrategy`.
 	 */
-	mergeStrategy: MERGE_STRATEGIES.REMOTE_WINS
+	mergeStrategy: MERGE_STRATEGIES.REMOTE_WINS,
+
+	recordDeepCopy: true,
+
+	recordDeepCompare: true
 };

--- a/src/record/json-path.js
+++ b/src/record/json-path.js
@@ -12,10 +12,9 @@ var cache = Object.create( null );
  * @returns {Mixed}
  */
 module.exports.get = function ( data, path, deepCopy ) {
-	var tokens = tokenize( path ),
-		i;
+	var tokens = tokenize( path );
 
-	for( i = 0; i < tokens.length; i++ ) {
+	for( var i = 0; i < tokens.length; i++ ) {
 		if( data[ tokens[ i ] ] !== undefined ) {
 			data = data[ tokens[ i ] ];
 		} else {
@@ -36,20 +35,19 @@ module.exports.get = function ( data, path, deepCopy ) {
  * @returns old or new state
  */
 module.exports.set = function( data, path, value, deepCopy ) {
-	var i,
-		tokens = tokenize( path );
+	var tokens = tokenize( path );
 
 	if ( deepCopy !== false ) {
 		value = utils.deepCopy( value );
 	}
 
 	if ( tokens.length > 0 ) {
-		data = utils.shallowCopy( data );
-
-		var node = data;
-
-		for( i = 0; i < tokens.length - 1; i++ ) {
-			if( node[ tokens[ i ] ] !== undefined ) {
+		var node = data = utils.shallowCopy( data );
+		for( var i = 0; i < tokens.length; i++ ) {
+			if ( i === tokens.length - 1) {
+				node[ tokens[ i ] ] = value;
+			}
+			else if( node[ tokens[ i ] ] !== undefined ) {
 				node = node[ tokens[ i ] ] = utils.shallowCopy( node[ tokens[ i ] ] );
 			}
 			else if( tokens[ i + 1 ] && !isNaN( tokens[ i + 1 ] ) ){
@@ -59,8 +57,6 @@ module.exports.set = function( data, path, value, deepCopy ) {
 				node = node[ tokens[ i ] ] = {};
 			}
 		}
-
-		node[ tokens[ i ] ] = value;
 	}
 	else {
 		data = value;
@@ -76,22 +72,15 @@ module.exports.set = function( data, path, value, deepCopy ) {
  * @returns Array of tokens
  */
 function tokenize( path ) {
-	path = path ? path.toString() : undefined
-
-	var tokens = cache[ path ];
-
-	if ( tokens ) {
-		return tokens;
+	if ( cache[ path ] ) {
+		return cache[ path ];
 	}
 
-	tokens = [];
-
-	var parts = path ? path.split( SPLIT_REG_EXP ) : [],
+	var parts = path !== undefined ? path.toString().split( SPLIT_REG_EXP ) : [],
 		tokens = [],
-		part,
-		i;
+		part;
 
-	for( i = 0; i < parts.length; i++ ) {
+	for( var i = 0; i < parts.length; i++ ) {
 		part = utils.trim( parts[ i ] );
 
 		if( part.length === 0 ) {
@@ -111,7 +100,5 @@ function tokenize( path ) {
 		tokens.push( part );
 	}
 
-	cache[ path ] = tokens;
-
-	return tokens;
+	return cache[ path ] = tokens;
 };

--- a/src/record/json-path.js
+++ b/src/record/json-path.js
@@ -41,25 +41,24 @@ module.exports.set = function( data, path, value, deepCopy ) {
 		value = utils.deepCopy( value );
 	}
 
-	if ( tokens.length > 0 ) {
-		var node = data = utils.shallowCopy( data );
-		for( var i = 0; i < tokens.length; i++ ) {
-			if ( i === tokens.length - 1) {
-				node[ tokens[ i ] ] = value;
-			}
-			else if( node[ tokens[ i ] ] !== undefined ) {
-				node = node[ tokens[ i ] ] = utils.shallowCopy( node[ tokens[ i ] ] );
-			}
-			else if( tokens[ i + 1 ] && !isNaN( tokens[ i + 1 ] ) ){
-				node = node[ tokens[ i ] ] = [];
-			}
-			else {
-				node = node[ tokens[ i ] ] = {};
-			}
-		}
+	if ( tokens.length === 0 ) {
+		return value;
 	}
-	else {
-		data = value;
+
+	var node = data = utils.shallowCopy( data );
+	for( var i = 0; i < tokens.length; i++ ) {
+		if ( i === tokens.length - 1) {
+			node[ tokens[ i ] ] = value;
+		}
+		else if( node[ tokens[ i ] ] !== undefined ) {
+			node = node[ tokens[ i ] ] = utils.shallowCopy( node[ tokens[ i ] ] );
+		}
+		else if( tokens[ i + 1 ] && !isNaN( tokens[ i + 1 ] ) ){
+			node = node[ tokens[ i ] ] = [];
+		}
+		else {
+			node = node[ tokens[ i ] ] = Object.create( null );
+		}
 	}
 
 	return data;
@@ -76,12 +75,12 @@ function tokenize( path ) {
 		return cache[ path ];
 	}
 
-	var parts = path !== undefined ? path.toString().split( SPLIT_REG_EXP ) : [],
-		tokens = [],
-		part;
+	var parts = path !== undefined ? path.toString().split( SPLIT_REG_EXP ) : [];
+
+	var tokens = [];
 
 	for( var i = 0; i < parts.length; i++ ) {
-		part = utils.trim( parts[ i ] );
+		var part = utils.trim( parts[ i ] );
 
 		if( part.length === 0 ) {
 			continue;

--- a/src/record/json-path.js
+++ b/src/record/json-path.js
@@ -13,12 +13,8 @@ var cache = Object.create( null );
 module.exports.get = function ( data, path, deepCopy ) {
 	var tokens = tokenize( path );
 
-	for( var i = 0; i < tokens.length; i++ ) {
-		if( data[ tokens[ i ] ] !== undefined ) {
-			data = data[ tokens[ i ] ];
-		} else {
-			return undefined;
-		}
+	for( var i = 0; data && i < tokens.length; i++ ) {
+		data = data[ tokens[ i ] ];
 	}
 
 	return deepCopy !== false ? utils.deepCopy( data ) : data;

--- a/src/record/json-path.js
+++ b/src/record/json-path.js
@@ -21,7 +21,7 @@ module.exports.get = function ( data, path, deepCopy ) {
 			data = data[ tokens[ i ] ];
 		}
 		else {
-			throw new Error( 'invalid data' );
+			throw new Error( 'invalid data or path' );
 		}
 	}
 

--- a/src/record/json-path.js
+++ b/src/record/json-path.js
@@ -13,8 +13,16 @@ var cache = Object.create( null );
 module.exports.get = function ( data, path, deepCopy ) {
 	var tokens = tokenize( path );
 
-	for( var i = 0; data && i < tokens.length; i++ ) {
-		data = data[ tokens[ i ] ];
+	for( var i = 0; i < tokens.length; i++ ) {
+		if ( data === undefined ) {
+			return undefined;
+		}
+		else if ( typeof data === 'object' ) {
+			data = data[ tokens[ i ] ];
+		}
+		else {
+			throw new Error( 'invalid data' );
+		}
 	}
 
 	return deepCopy !== false ? utils.deepCopy( data ) : data;

--- a/src/record/json-path.js
+++ b/src/record/json-path.js
@@ -17,12 +17,10 @@ module.exports.get = function ( data, path, deepCopy ) {
 		if ( data === undefined ) {
 			return undefined;
 		}
-		else if ( typeof data === 'object' ) {
-			data = data[ tokens[ i ] ];
-		}
-		else {
+		if ( typeof data !== 'object' ) {
 			throw new Error( 'invalid data or path' );
 		}
+		data = data[ tokens[ i ] ];
 	}
 
 	return deepCopy !== false ? utils.deepCopy( data ) : data;

--- a/src/record/json-path.js
+++ b/src/record/json-path.js
@@ -35,14 +35,9 @@ module.exports.get = function ( data, path, deepCopy ) {
  * @public
  * @returns old or new state
  */
-module.exports.set = function( data, path, value, deepCopy, deepCompare ) {
+module.exports.set = function( data, path, value, deepCopy ) {
 	var i,
-		tokens = tokenize( path ),
-		oldValue = module.exports.get( data, path );
-
-	if (deepCompare !== false ? utils.deepEquals( oldValue, value ) : oldValue === value) {
-		return data;
-	}
+		tokens = tokenize( path );
 
 	if ( deepCopy !== false ) {
 		value = utils.deepCopy( value );

--- a/src/record/json-path.js
+++ b/src/record/json-path.js
@@ -1,5 +1,5 @@
 var utils = require( '../utils/utils' ),
-	SPLIT_REG_EXP = /[\.\[\]]/g;
+	PARTS_REG_EXP = /([^\.\[\]\s]+)/g;
 
 var cache = Object.create( null );
 
@@ -76,24 +76,13 @@ function tokenize( path ) {
 		return cache[ path ];
 	}
 
-	var parts = path !== undefined
-		? path.toString().replace(/\s/g, '').split( SPLIT_REG_EXP )
-		: [];
+	var parts = path !== undefined ? String( path ).match(PARTS_REG_EXP) : [];
 
-	var tokens = [];
-
-	for( var i = 0; i < parts.length; i++ ) {
-		if( parts[ i ].length === 0 ) {
-			continue;
-		}
-
-		if( !isNaN( parts[ i ] ) ) {
-			tokens.push( parseInt( parts[ i ], 10 ) );
-		}
-		else {
-			tokens.push( parts[ i ] );
-		}
+	if ( !parts ) {
+		throw new Error('invalid path ' + path)
 	}
 
-	return cache[ path ] = tokens;
+	return cache[ path ] = parts.map( function( part ) {
+		return !isNaN( part ) ? parseInt( part, 10 ) : part;
+	} );
 };

--- a/src/record/json-path.js
+++ b/src/record/json-path.js
@@ -1,6 +1,5 @@
 var utils = require( '../utils/utils' ),
-	SPLIT_REG_EXP = /[\.\[\]]/g,
-	ASTERISK = '*';
+	SPLIT_REG_EXP = /[\.\[\]]/g;
 
 var cache = Object.create( null );
 
@@ -90,15 +89,10 @@ function tokenize( path ) {
 
 		if( !isNaN( parts[ i ] ) ) {
 			tokens.push( parseInt( parts[ i ], 10 ) );
-			continue;
 		}
-
-		if( parts[ i ] === ASTERISK ) {
-			tokens.push( true );
-			continue;
+		else {
+			tokens.push( parts[ i ] );
 		}
-
-		tokens.push( parts[ i ] );
 	}
 
 	return cache[ path ] = tokens;

--- a/src/record/json-path.js
+++ b/src/record/json-path.js
@@ -77,28 +77,28 @@ function tokenize( path ) {
 		return cache[ path ];
 	}
 
-	var parts = path !== undefined ? path.toString().split( SPLIT_REG_EXP ) : [];
+	var parts = path !== undefined
+		? path.toString().replace(/\s/g, '').split( SPLIT_REG_EXP )
+		: [];
 
 	var tokens = [];
 
 	for( var i = 0; i < parts.length; i++ ) {
-		var part = utils.trim( parts[ i ] );
-
-		if( part.length === 0 ) {
+		if( parts[ i ].length === 0 ) {
 			continue;
 		}
 
-		if( !isNaN( part ) ) {
-			tokens.push( parseInt( part, 10 ) );
+		if( !isNaN( parts[ i ] ) ) {
+			tokens.push( parseInt( parts[ i ], 10 ) );
 			continue;
 		}
 
-		if( part === ASTERISK ) {
+		if( parts[ i ] === ASTERISK ) {
 			tokens.push( true );
 			continue;
 		}
 
-		tokens.push( part );
+		tokens.push( parts[ i ] );
 	}
 
 	return cache[ path ] = tokens;

--- a/src/record/json-path.js
+++ b/src/record/json-path.js
@@ -32,7 +32,7 @@ module.exports.get = function ( data, path, deepCopy ) {
  * @param {Mixed} value
  *
  * @public
- * @returns old or new state
+ * @returns updated value
  */
 module.exports.set = function( data, path, value, deepCopy ) {
 	var tokens = tokenize( path );
@@ -45,7 +45,9 @@ module.exports.set = function( data, path, value, deepCopy ) {
 		return value;
 	}
 
-	var node = data = utils.shallowCopy( data );
+	data = utils.shallowCopy( data );
+
+	var node = data;
 	for( var i = 0; i < tokens.length; i++ ) {
 		if ( i === tokens.length - 1) {
 			node[ tokens[ i ] ] = value;

--- a/src/record/record.js
+++ b/src/record/record.js
@@ -473,16 +473,15 @@ Record.prototype._applyChange = function( newData ) {
  * @returns {Object} arguments map
  */
 Record.prototype._normalizeArguments = function( args ) {
-	var result = {},
-		i;
-
 	// If arguments is already a map of normalized parameters
 	// (e.g. when called by AnonymousRecord), just return it.
 	if( args.length === 1 && typeof args[ 0 ] === 'object' ) {
 		return args[ 0 ];
 	}
 
-	for( i = 0; i < args.length; i++ ) {
+	var result = Object.create( null );
+
+	for( var i = 0; i < args.length; i++ ) {
 		if( typeof args[ i ] === 'string' ) {
 			result.path = args[ i ];
 		}

--- a/src/record/record.js
+++ b/src/record/record.js
@@ -327,7 +327,7 @@ Record.prototype._sendUpdate = function ( path, data ) {
 Record.prototype._onRecordRecovered = function( remoteVersion, remoteData, error, data ) {
 	if( !error ) {
 		this.version = remoteVersion;
-		if ( data !== this._$data && !utils.deepEquals( data, this._$data ) ) {
+		if ( !utils.deepEquals( data, this._$data ) ) {
 			this._sendUpdate( undefined, data );
 		}
 		this._applyChange( data );
@@ -463,7 +463,7 @@ Record.prototype._applyChange = function( newData ) {
 		var newValue = jsonPath.get( newData, paths[ i ], false );
 		var oldValue = jsonPath.get( oldData, paths[ i ], false );
 
-		if( newValue !== oldValue && !utils.deepEquals( newValue, oldValue ) ) {
+		if( !utils.deepEquals( newValue, oldValue ) ) {
 			this._eventEmitter.emit( paths[ i ], this.get( paths[ i ] ) );
 		}
 	}

--- a/src/record/record.js
+++ b/src/record/record.js
@@ -1,11 +1,10 @@
-var JsonPath = require( './json-path' ),
+var jsonPath = require( './json-path' ),
 	utils = require( '../utils/utils' ),
 	ResubscribeNotifier = require( '../utils/resubscribe-notifier' ),
 	EventEmitter = require( 'component-emitter' ),
 	C = require( '../constants/constants' ),
 	messageBuilder = require( '../message/message-builder' ),
-	messageParser = require( '../message/message-parser' ),
-	ALL_EVENT = 'ALL_EVENT';
+	messageParser = require( '../message/message-parser' );
 
 /**
  * This class represents a single record - an observable
@@ -30,11 +29,8 @@ var Record = function( name, recordOptions, connection, options, client ) {
 	this._options = options;
 	this.isReady = false;
 	this.isDestroyed = false;
-	this._$data = {};
+	this._$data = Object.create( null );
 	this.version = null;
-	this._paths = {};
-	this._oldValue = null;
-	this._oldPathValues = null;
 	this._eventEmitter = new EventEmitter();
 	this._queuedMethodCalls = [];
 
@@ -87,15 +83,7 @@ Record.prototype.setMergeStrategy = function( mergeStrategy ) {
  * @returns {Mixed} value
  */
 Record.prototype.get = function( path ) {
-	var value;
-
-	if( path ) {
-		value = this._getPath( path ).getValue();
-	} else {
-		value = this._$data;
-	}
-
-	return utils.deepCopy( value );
+	return jsonPath.get( this._$data, path, this._options.recordDeepCopy );
 };
 
 /**
@@ -125,34 +113,34 @@ Record.prototype.set = function( pathOrData, data ) {
 		return this;
 	}
 
-	if( arguments.length === 2 && utils.deepEquals( this._getPath( pathOrData ).getValue(), data ) ) {
-		return this;
-	}
-	else if( arguments.length === 1 && utils.deepEquals( this._$data, pathOrData ) ) {
+	var path = arguments.length === 1 ? undefined : pathOrData;
+	data = path ? data : pathOrData;
+
+	var oldValue = this._$data;
+	var newValue = jsonPath.set( this._$data, path, data, this._options.recordDeepCopy, this._options.recordDeepCompare );
+
+	if ( newValue === oldValue ) {
 		return this;
 	}
 
-	this._beginChange();
 	this.version++;
 
-	if( arguments.length === 1 ) {
-		this._$data = ( typeof pathOrData == 'object' ) ? utils.deepCopy( pathOrData ) : pathOrData;
+	if( !path ) {
 		this._connection.sendMsg( C.TOPIC.RECORD, C.ACTIONS.UPDATE, [
 			this.name,
 			this.version,
-			this._$data
+			data
 		]);
 	} else {
-		this._getPath( pathOrData ).setValue( ( typeof data == 'object' ) ? utils.deepCopy( data ): data );
 		this._connection.sendMsg( C.TOPIC.RECORD, C.ACTIONS.PATCH, [
 			this.name,
 			this.version,
-			pathOrData,
+			path,
 			messageBuilder.typed( data )
 		]);
 	}
 
-	this._completeChange();
+	this._applyChange( newValue );
 	return this;
 };
 
@@ -183,16 +171,12 @@ Record.prototype.subscribe = function( path, callback, triggerNow ) {
 	}
 
 	if( args.triggerNow ) {
-		this.whenReady(function () {
-			this._eventEmitter.on( args.path || ALL_EVENT, args.callback );
-			if( args.path ) {
-				args.callback( this._getPath( args.path ).getValue() );
-			} else {
-				args.callback( this._$data );
-			}
-		}.bind(this));
+		this.whenReady( function () {
+			this._eventEmitter.on( args.path, args.callback );
+			args.callback( this.get( args.path ) );
+		}.bind(this) );
 	} else {
-		this._eventEmitter.on( args.path || ALL_EVENT, args.callback );
+		this._eventEmitter.on( args.path, args.callback );
 	}
 };
 
@@ -219,11 +203,7 @@ Record.prototype.unsubscribe = function( pathOrCallback, callback ) {
 	if( this._checkDestroyed( 'unsubscribe' ) ) {
 		return;
 	}
-	if ( args.path ) {
-		this._eventEmitter.off( args.path, args.callback );
-	} else {
-		this._eventEmitter.off( ALL_EVENT, args.callback );
-	}
+	this._eventEmitter.off( args.path, args.callback );
 };
 
 /**
@@ -415,16 +395,12 @@ Record.prototype._applyUpdate = function( message ) {
 		return;
 	}
 
-	this._beginChange();
 	this.version = version;
 
-	if( message.action === C.ACTIONS.PATCH ) {
-		this._getPath( message.data[ 2 ] ).setValue( data );
-	} else {
-		this._$data = data;
-	}
+	var path = message.action === C.ACTIONS.PATCH ? message.data[ 2 ] : undefined;
+	var newValue = jsonPath.set( this._$data, path, data, false, this._options.recordDeepCompare );
 
-	this._completeChange();
+	this._applyChange( newValue );
 };
 
 /**
@@ -436,10 +412,9 @@ Record.prototype._applyUpdate = function( message ) {
  * @returns {void}
  */
 Record.prototype._onRead = function( message ) {
-	this._beginChange();
 	this.version = parseInt( message.data[ 1 ], 10 );
-	this._$data = JSON.parse( message.data[ 2 ] );
-	this._completeChange();
+	var newValue = jsonPath.set( this._$data, undefined, JSON.parse( message.data[ 2 ] ), false, this._options.recordDeepCompare );
+	this._applyChange( newValue );
 	this._setReady();
 };
 
@@ -470,81 +445,28 @@ Record.prototype._setReady = function() {
  	this._connection.sendMsg( C.TOPIC.RECORD, C.ACTIONS.CREATEORREAD, [ this.name ] );
  };
 
-
 /**
- * Returns an instance of JsonPath for a specific path. Creates the instance if it doesn't
- * exist yet
- *
- * @param   {String} path
- *
- * @returns {JsonPath}
- */
-Record.prototype._getPath = function( path ) {
-	if( !this._paths[ path ] ) {
-		this._paths[ path ] = new JsonPath( this, path );
-	}
-
-	return this._paths[ path ];
-};
-
-/**
- * First of two steps that are called for incoming and outgoing updates.
- * Saves the current value of all paths the app is subscribed to.
- *
- * @private
- * @returns {void}
- */
-Record.prototype._beginChange = function() {
-	if( !this._eventEmitter._callbacks ) {
-		return;
-	}
-
-	var paths = Object.keys( this._eventEmitter._callbacks ),
-		i;
-
-	this._oldPathValues = {};
-
-	if( this._eventEmitter.hasListeners( ALL_EVENT ) ) {
-		this._oldValue = this.get();
-	}
-
-	for( i = 0; i < paths.length; i++ ) {
-		if( paths[ i ] !== ALL_EVENT ) {
-			this._oldPathValues[ paths[ i ] ] = this._getPath( paths[ i ] ).getValue();
-		}
-	}
-};
-
-/**
- * Second of two steps that are called for incoming and outgoing updates.
  * Compares the new values for every path with the previously stored ones and
  * updates the subscribers if the value has changed
  *
  * @private
  * @returns {void}
  */
-Record.prototype._completeChange = function() {
-	if( this._eventEmitter.hasListeners( ALL_EVENT ) && !utils.deepEquals( this._oldValue, this._$data ) ) {
-		this._eventEmitter.emit( ALL_EVENT, this.get() );
-	}
+Record.prototype._applyChange = function( newValue ) {
+	var oldValue = this._$data;
+	this._$data = newValue;
 
-	this._oldValue = null;
-
-	if( this._oldPathValues === null ) {
+	if ( newValue === oldValue || !this._eventEmitter._callbacks ) {
 		return;
 	}
 
-	var path, currentValue;
+	var i, path, paths = Object.keys( this._eventEmitter._callbacks );
 
-	for( path in this._oldPathValues ) {
-		currentValue = this._getPath( path ).getValue();
-
-		if( currentValue !== this._oldPathValues[ path ] ) {
-			this._eventEmitter.emit( path, currentValue );
+	for( i = 0; i < paths.length; i++ ) {
+		if( jsonPath.get( newValue, paths[ i ], false ) !== jsonPath.get( oldValue, paths[ i ], false ) ) {
+			this._eventEmitter.emit( paths[ i ], jsonPath.get( newValue, paths[ i ], this._options.recordDeepCopy ) );
 		}
 	}
-
-	this._oldPathValues = null;
 };
 
 /**

--- a/src/record/record.js
+++ b/src/record/record.js
@@ -116,12 +116,15 @@ Record.prototype.set = function( pathOrData, data ) {
 	var path = arguments.length === 1 ? undefined : pathOrData;
 	data = path ? data : pathOrData;
 
-	if ( utils.deepEquals( data, jsonPath.get( this._$data, path ) ) ) {
+	var oldValue = this._$data;
+	var newValue = jsonPath.set( oldValue, path, data, this._options.recordDeepCopy );
+
+	if ( oldValue === newValue ) {
 		return this;
 	}
 
 	this._sendUpdate( path, data );
-	this._applyChange( jsonPath.set( this._$data, path, data, this._options.recordDeepCopy ) );
+	this._applyChange( newValue );
 	return this;
 };
 
@@ -327,10 +330,16 @@ Record.prototype._sendUpdate = function ( path, data ) {
 Record.prototype._onRecordRecovered = function( remoteVersion, remoteData, error, data ) {
 	if( !error ) {
 		this.version = remoteVersion;
-		if ( !utils.deepEquals( data, this._$data ) ) {
-			this._sendUpdate( undefined, data );
+
+		var oldValue = this._$data;
+		var newValue = jsonPath.set( oldValue, undefined, data, false );
+
+		if ( oldValue === newValue ) {
+			return;
 		}
-		this._applyChange( data );
+
+		this._sendUpdate( undefined, data );
+		this._applyChange( newValue );
 	} else {
 		this.emit( 'error', C.EVENT.VERSION_EXISTS, 'received update for ' + remoteVersion + ' but version is ' + this.version );
 	}
@@ -463,7 +472,7 @@ Record.prototype._applyChange = function( newData ) {
 		var newValue = jsonPath.get( newData, paths[ i ], false );
 		var oldValue = jsonPath.get( oldData, paths[ i ], false );
 
-		if( !utils.deepEquals( newValue, oldValue ) ) {
+		if( newValue !== oldValue ) {
 			this._eventEmitter.emit( paths[ i ], this.get( paths[ i ] ) );
 		}
 	}

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -116,9 +116,11 @@ exports.shallowCopy = function ( obj ) {
 		return obj.slice( 0 );
 	}
 	else if (typeof obj === 'object') {
-	  var copy = Object.create( null );
-	  for ( var prop in obj ) {
-			copy[prop] = obj[prop];
+		var copy = Object.create( null );
+		for ( var prop in obj ) {
+			if ( obj.hasOwnProperty( prop ) ) {
+				copy[prop] = obj[prop];
+			}
 	  }
 	  return copy;
 	}

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -78,9 +78,13 @@ exports.trim = function( inputString ) {
  * @returns {Boolean} isEqual
  */
 exports.deepEquals= function( objA, objB ) {
-	if( typeof objA !== OBJECT || typeof objB !== OBJECT ) {
-		return objA === objB;
-	} else {
+	if ( objA === objB ) {
+		return true
+	}
+	else if( typeof objA !== OBJECT || typeof objB !== OBJECT ) {
+		return false;
+	}
+	else {
 		return JSON.stringify( objA ) === JSON.stringify( objB );
 	}
 };

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -116,11 +116,9 @@ exports.shallowCopy = function ( obj ) {
 		return obj.slice( 0 );
 	}
 	else if (typeof obj === 'object') {
-	  var prop, copy = {};
-	  for ( prop in obj ) {
-			if ( obj.hasOwnProperty(prop) ) {
-				copy[prop] = obj[prop];
-			}
+	  var copy = Object.create( null );
+	  for ( var prop in obj ) {
+			copy[prop] = obj[prop];
 	  }
 	  return copy;
 	}

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -117,11 +117,10 @@ exports.shallowCopy = function ( obj ) {
 	}
 	else if (typeof obj === 'object') {
 		var copy = Object.create( null );
-		for ( var prop in obj ) {
-			if ( !obj.hasOwnProperty || obj.hasOwnProperty( prop ) ) {
-				copy[prop] = obj[prop];
-			}
-	  }
+		var props = Object.keys( obj );
+		for ( var i = 0; i < props.length; i++ ) {
+			copy[ props[ i ] ] = obj[ props[ i ] ];
+		}
 	  return copy;
 	}
 	return obj;

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -112,10 +112,10 @@ exports.deepCopy = function( obj ) {
 };
 
 exports.shallowCopy = function ( obj ) {
-	if ( Array.isArray(obj) ) {
+	if ( Array.isArray( obj ) ) {
 		return obj.slice( 0 );
 	}
-	else if (typeof obj === 'object') {
+	else if ( typeof obj === 'object' ) {
 		var copy = Object.create( null );
 		var props = Object.keys( obj );
 		for ( var i = 0; i < props.length; i++ ) {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -118,7 +118,7 @@ exports.shallowCopy = function ( obj ) {
 	else if (typeof obj === 'object') {
 		var copy = Object.create( null );
 		for ( var prop in obj ) {
-			if ( obj.hasOwnProperty( prop ) ) {
+			if ( !obj.hasOwnProperty || obj.hasOwnProperty( prop ) ) {
 				copy[prop] = obj[prop];
 			}
 	  }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -110,3 +110,19 @@ exports.deepCopy = function( obj ) {
 		return obj;
 	}
 };
+
+exports.shallowCopy = function ( obj ) {
+	if ( Array.isArray(obj) ) {
+		return obj.slice( 0 );
+	}
+	else if (typeof obj === 'object') {
+	  var prop, copy = {};
+	  for ( prop in obj ) {
+			if ( obj.hasOwnProperty(prop) ) {
+				copy[prop] = obj[prop];
+			}
+	  }
+	  return copy;
+	}
+	return obj;
+}

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -115,7 +115,7 @@ exports.shallowCopy = function ( obj ) {
 	if ( Array.isArray( obj ) ) {
 		return obj.slice( 0 );
 	}
-	else if ( typeof obj === 'object' ) {
+	else if ( typeof obj === OBJECT ) {
 		var copy = Object.create( null );
 		var props = Object.keys( obj );
 		for ( var i = 0; i < props.length; i++ ) {

--- a/test-unit/unit/record/json-pathSpec.js
+++ b/test-unit/unit/record/json-pathSpec.js
@@ -1,4 +1,5 @@
 var jsonPath = require( '../../../src/record/json-path' );
+var utils = require( '../../../src/utils/utils' );
 
 describe('paths are tokenized and retrieved correctly', function(){
 	var testRecord = { _$data: {
@@ -13,6 +14,10 @@ describe('paths are tokenized and retrieved correctly', function(){
 		],
 		1234: 'integer index'
 	}};
+
+	beforeEach( function() {
+		jasmine.addCustomEqualityTester(utils.deepEquals);
+	} );
 
 	it( 'retrieves simple paths', function(){
 		expect( jsonPath.get( testRecord._$data, 'firstname') ).toBe( 'Wolfram' );
@@ -73,6 +78,10 @@ describe('paths are tokenized and retrieved correctly', function(){
 
 describe( 'objects are created from paths and their value is set correctly', function(){
 
+	beforeEach( function() {
+		jasmine.addCustomEqualityTester(utils.deepEquals);
+	} );
+
 	it( 'sets simple values', function(){
 		var record = { _$data:{}};
 		record._$data = jsonPath.set( record._$data, 'firstname', 'Wolfram' );
@@ -95,14 +104,13 @@ describe( 'objects are created from paths and their value is set correctly', fun
 		var record = { _$data:{}};
 		record._$data = jsonPath.set( record._$data, 'pastAddresses[1].street', 'someStreet' );
 		expect( jsonPath.get( record._$data, 'pastAddresses[1].street' ) ).toBe( 'someStreet');
-		//TODO: Check why equals doesn't work
-		expect( JSON.stringify( record._$data )  ).toEqual( JSON.stringify( {
+		expect( record._$data ).toEqual({
 			pastAddresses: [
 			undefined,
 			{
 				street: 'someStreet'
 			}]
-		}) );
+		});
 	});
 
 	it( 'extends existing objects', function(){

--- a/test-unit/unit/record/json-pathSpec.js
+++ b/test-unit/unit/record/json-pathSpec.js
@@ -1,4 +1,4 @@
-var JsonPath = require( '../../../src/record/json-path' );
+var jsonPath = require( '../../../src/record/json-path' );
 
 describe('paths are tokenized and retrieved correctly', function(){
 	var testRecord = { _$data: {
@@ -15,90 +15,75 @@ describe('paths are tokenized and retrieved correctly', function(){
 	}};
 
 	it( 'retrieves simple paths', function(){
-		var jsonPath = new JsonPath( testRecord, 'firstname' );
-		expect( jsonPath.getValue() ).toBe( 'Wolfram' );
+		expect( jsonPath.get( testRecord._$data, 'firstname') ).toBe( 'Wolfram' );
 	});
 
 	it( 'retrieves nested paths', function(){
-		var jsonPath = new JsonPath( testRecord, 'address.street' );
-		expect( jsonPath.getValue() ).toBe( 'currentStreet' );
+		expect( jsonPath.get( testRecord._$data, 'address.street' ) ).toBe( 'currentStreet' );
 	});
 
 	it( 'retrieves array entries', function(){
-		var jsonPath = new JsonPath( testRecord, 'pastAddresses[1]' );
-		expect( jsonPath.getValue() ).toEqual( { street: 'secondstreet', postCode: 2002 } );
+		expect( jsonPath.get( testRecord._$data, 'pastAddresses[1]' ) ).toEqual( { street: 'secondstreet', postCode: 2002 } );
 	});
 
 	it( 'retrieves other array entries', function(){
-		var jsonPath = new JsonPath( testRecord, 'pastAddresses[0]' );
-		expect( jsonPath.getValue() ).toEqual( { street: 'firststreet', postCode: 1001 } );
+		expect( jsonPath.get( testRecord._$data, 'pastAddresses[0]' ) ).toEqual( { street: 'firststreet', postCode: 1001 } );
 	});
 
 	it( 'retrieves values from objects within arrays', function(){
-		var jsonPath = new JsonPath( testRecord, 'pastAddresses[0].postCode' );
-		expect( jsonPath.getValue() ).toBe( 1001 );
+		expect( jsonPath.get( testRecord._$data, 'pastAddresses[0].postCode' ) ).toBe( 1001 );
 	});
 
 	it( 'handles whitespace', function(){
-		var jsonPath = new JsonPath( testRecord, ' pastAddresses[ 1 ].postCode ' );
-		expect( jsonPath.getValue() ).toBe( 2002 );
+		expect( jsonPath.get( testRecord._$data, ' pastAddresses[ 1 ].postCode ' ) ).toBe( 2002 );
 	});
 
 	it( 'handles integers', function(){
-		var jsonPath = new JsonPath( testRecord, 1234 );
-		expect( jsonPath.getValue() ).toBe( 'integer index' );
+		expect( jsonPath.get( testRecord._$data, 1234 ) ).toBe( 'integer index' );
 	});
 
 	it( 'returns undefined for non existing keys', function(){
-		var jsonPath = new JsonPath( testRecord, 'doesNotExist' );
-		expect( jsonPath.getValue() ).toBe( undefined );
+		expect( jsonPath.get( testRecord._$data, 'doesNotExist' ) ).toBe( undefined );
 	});
 
 	it( 'returns undefined for non existing nested keys', function(){
-		var jsonPath = new JsonPath( testRecord, 'address.number' );
-		expect( jsonPath.getValue() ).toBe( undefined );
+		expect( jsonPath.get( testRecord._$data, 'address.number' ) ).toBe( undefined );
 	});
 
 	it( 'returns undefined for existing array indices', function(){
-		var jsonPath = new JsonPath( testRecord, 'pastAddresses[3]' );
-		expect( jsonPath.getValue() ).toBe( undefined );
+		expect( jsonPath.get( testRecord._$data, 'pastAddresses[3]' ) ).toBe( undefined );
 	});
 
 	it( 'returns undefined for negative array indices', function(){
-		var jsonPath = new JsonPath( testRecord, 'pastAddresses[-1]' );
-		expect( jsonPath.getValue() ).toBe( undefined );
+		expect( jsonPath.get( testRecord._$data, 'pastAddresses[-1]' ) ).toBe( undefined );
 	});
 
 	it( 'detects changes', function(){
-		var jsonPath = new JsonPath( testRecord, 'firstname' );
-		expect( jsonPath.getValue() ).toBe( 'Wolfram' );
+		expect( jsonPath.get( testRecord._$data, 'firstname' ) ).toBe( 'Wolfram' );
 		testRecord._$data.firstname = 'Egon';
-		expect( jsonPath.getValue() ).toBe( 'Egon' );
+		expect( jsonPath.get( testRecord._$data, 'firstname' ) ).toBe( 'Egon' );
 	});
 
 	it( 'detects changes to arrays', function(){
-		var jsonPath = new JsonPath( testRecord, 'pastAddresses[1].street' );
-		expect( jsonPath.getValue() ).toBe( 'secondstreet' );
+		expect( jsonPath.get( testRecord._$data, 'pastAddresses[1].street' ) ).toBe( 'secondstreet' );
 		testRecord._$data.pastAddresses.pop();
-		expect( jsonPath.getValue() ).toBe( undefined );
+		expect( jsonPath.get( testRecord._$data, 'pastAddresses[1].street' ) ).toBe( undefined );
 	});
 });
 
 describe( 'objects are created from paths and their value is set correctly', function(){
-	
+
 	it( 'sets simple values', function(){
-		var record = { _$data:{}},
-			jsonPath = new JsonPath( record, 'firstname' );
-		jsonPath.setValue( 'Wolfram' );
-		expect( jsonPath.getValue() ).toBe( 'Wolfram');
+		var record = { _$data:{}};
+		record._$data = jsonPath.set( record._$data, 'firstname', 'Wolfram' );
+		expect( jsonPath.get( record._$data, 'firstname' ) ).toBe( 'Wolfram');
 		expect( record._$data ).toEqual({ firstname: 'Wolfram' });
 	});
 
 	it( 'sets values for nested objects', function(){
-		var record = { _$data:{}},
-			jsonPath = new JsonPath( record, 'adress.street' );
-		jsonPath.setValue( 'someStreet' );
-		expect( jsonPath.getValue() ).toBe( 'someStreet');
+		var record = { _$data:{}};
+		record._$data = jsonPath.set( record._$data, 'adress.street', 'someStreet' );
+		expect( jsonPath.get( record._$data, 'adress.street' ) ).toBe( 'someStreet');
 		expect( record._$data ).toEqual({
 			adress: {
 				street: 'someStreet'
@@ -107,10 +92,9 @@ describe( 'objects are created from paths and their value is set correctly', fun
 	});
 
 	it( 'sets values for arrays', function(){
-		var record = { _$data:{}},
-			jsonPath = new JsonPath( record, 'pastAddresses[1].street' );
-		jsonPath.setValue( 'someStreet' );
-		expect( jsonPath.getValue() ).toBe( 'someStreet');
+		var record = { _$data:{}};
+		record._$data = jsonPath.set( record._$data, 'pastAddresses[1].street', 'someStreet' );
+		expect( jsonPath.get( record._$data, 'pastAddresses[1].street' ) ).toBe( 'someStreet');
 		//TODO: Check why equals doesn't work
 		expect( JSON.stringify( record._$data )  ).toEqual( JSON.stringify( {
 			pastAddresses: [
@@ -122,10 +106,9 @@ describe( 'objects are created from paths and their value is set correctly', fun
 	});
 
 	it( 'extends existing objects', function(){
-		var record = { _$data: { firstname: 'Wolfram' } },
-			jsonPath = new JsonPath( record, 'lastname' );
-		jsonPath.setValue( 'Hempel' );
-		expect( jsonPath.getValue() ).toBe( 'Hempel');
+		var record = { _$data: { firstname: 'Wolfram' } };
+		record._$data = jsonPath.set( record._$data, 'lastname', 'Hempel' );
+		expect( jsonPath.get( record._$data, 'lastname' ) ).toBe( 'Hempel');
 		expect( record._$data ).toEqual({
 			firstname: 'Wolfram',
 			lastname: 'Hempel'
@@ -136,10 +119,9 @@ describe( 'objects are created from paths and their value is set correctly', fun
 		var record = {_$data: {
 			firstname: 'Wolfram',
 			animals: [ 'Bear', 'Cow', 'Ostrich' ]
-		}},
-		jsonPath = new JsonPath( record, 'animals[ 1 ]' );
-		jsonPath.setValue( 'Emu' );
-		expect( jsonPath.getValue() ).toBe( 'Emu');
+		}};
+		record._$data = jsonPath.set( record._$data, 'animals[ 1 ]', 'Emu' );
+		expect( jsonPath.get( record._$data, 'animals[ 1 ]' ) ).toBe( 'Emu');
 		expect( record._$data ).toEqual({
 			firstname: 'Wolfram',
 			animals: [ 'Bear', 'Emu', 'Ostrich' ]


### PR DESCRIPTION
This continues from #214. By patching the existing `_$data` only on diffs we can always use reference equality instead of `deepEquals`. This makes things like the subscribe callback check, delta calculation and react (pure) components backed by records much faster.

The  `jsonPath.patch` can be further optimised later as an iterative implementation, which would be faster (for deeply nested records) than the recursive one in this PR. Further optimisation would also be to avoid doing overlapping equality checks.