### PR TITLE
index is undefined when record is not ready

### DIFF
--- a/src/record/list.js
+++ b/src/record/list.js
@@ -103,7 +103,7 @@ List.prototype.setEntries = function( entries ) {
 /**
  * Removes an entry from the list
  *
- * @param   {String} entry
+ * @param {String} entry
  * @param {Number} [index]
  *
  * @public
@@ -111,7 +111,7 @@ List.prototype.setEntries = function( entries ) {
  */
 List.prototype.removeEntry = function( entry, index ) {
 	if( this._record.isReady === false ) {
-		this._queuedMethods.push( this.removeEntry.bind( this, entry ) );
+		this._queuedMethods.push( this.removeEntry.bind( this, entry, index ) );
 		return;
 	}
 
@@ -145,7 +145,7 @@ List.prototype.addEntry = function( entry, index ) {
 	}
 
 	if( this._record.isReady === false ) {
-		this._queuedMethods.push( this.addEntry.bind( this, entry ) );
+		this._queuedMethods.push( this.addEntry.bind( this, entry, index ) );
 		return;
 	}
 

--- a/test-unit/unit/record/list-spec.js
+++ b/test-unit/unit/record/list-spec.js
@@ -103,4 +103,26 @@ describe( 'lists contain arrays of record names', function(){
 		list.setEntries([ 'q' ]);
 		expect( changeCallback.calls.count() ).toBe( 10 );
 	});
+
+	it( 'adding entries, methods are queued when record is not ready, correct indexes', function(){
+		list._record.isReady = false;
+		list.setEntries([ 'a','c','e' ]);
+		list.addEntry('b', 1);
+		list.addEntry('d', 3);
+		expect( list._queuedMethods.length ).toEqual(3);
+		list._record.isReady = true;
+		list._onReady();
+		expect( list.getEntries() ).toEqual([ 'a','b','c','d','e' ]);
+	});
+
+	it( 'removing entries, methods are queued when record is not ready, correct indexes', function(){
+		list._record.isReady = false;
+		list.setEntries([ 'b','a','b','c','b' ]);
+		list.removeEntry('b', 0);
+		list.removeEntry('b', 3);
+		expect( list._queuedMethods.length ).toEqual(3);
+		list._record.isReady = true;
+		list._onReady();
+		expect( list.getEntries() ).toEqual([ 'a','b','c' ]);
+	});
 });


### PR DESCRIPTION
If the record isn't in a ready state, calls to `list.removeEntry()` and `list.addEntry()` will not work since the queued methods will always ignore the provided index.