### PR TITLE
Added support for non-NaNish base 16 numbers in jsonpath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ node_modules
 .lock-wscript
 
 test-page-webpack/dist
+
+*.iml
+.idea

--- a/src/record/json-path.js
+++ b/src/record/json-path.js
@@ -124,6 +124,6 @@ function tokenize( path ) {
 	}
 
 	return cache[ path ] = parts.map( function( part ) {
-		return !isNaN( part ) ? parseInt( part, 10 ) : part;
+		return part;
 	} );
 };

--- a/src/record/json-path.js
+++ b/src/record/json-path.js
@@ -123,7 +123,5 @@ function tokenize( path ) {
 		throw new Error('invalid path ' + path)
 	}
 
-	return cache[ path ] = parts.map( function( part ) {
-		return part;
-	} );
+	return cache[ path ] = parts;
 };

--- a/test-unit/unit/record/json-pathSpec.js
+++ b/test-unit/unit/record/json-pathSpec.js
@@ -139,7 +139,7 @@ describe( 'objects are created from paths and their value is set correctly', fun
 
 	it( 'even when the path is not NaNish and could be interpreted as a base 16 number', function() {
 		var record = {};
-		let pathName = '0x02335';
+		var pathName = '0x02335';
 		record = jsonPath.set( record, pathName, 'value' );
 		expect( record[ 0 ] ).toBe( undefined );
 		expect( record[ pathName ] ).toBe( 'value' );

--- a/test-unit/unit/record/json-pathSpec.js
+++ b/test-unit/unit/record/json-pathSpec.js
@@ -137,6 +137,16 @@ describe( 'objects are created from paths and their value is set correctly', fun
 		});
 	});
 
+	it( 'even when the path is not NaNish and could be interpreted as a base 16 number', function() {
+		var record = {};
+    let pathName = '0x02335';
+    record = jsonPath.set( record, pathName, 'value' );
+    expect( record[ 0 ] ).toBe( undefined );
+		expect( record[ pathName] ).toBe( 'value' );
+    expect( jsonPath.get( record, pathName )).toBe( 'value' );
+    expect( record[ pathName ]).toBe( 'value' );
+	})
+
 	it( 'extends existing arrays', function(){
 		var record = {_$data: {
 			firstname: 'Wolfram',

--- a/test-unit/unit/record/json-pathSpec.js
+++ b/test-unit/unit/record/json-pathSpec.js
@@ -142,9 +142,9 @@ describe( 'objects are created from paths and their value is set correctly', fun
 		let pathName = '0x02335';
 		record = jsonPath.set( record, pathName, 'value' );
 		expect( record[ 0 ] ).toBe( undefined );
-		expect( record[ pathName] ).toBe( 'value' );
+		expect( record[ pathName ] ).toBe( 'value' );
 		expect( jsonPath.get( record, pathName )).toBe( 'value' );
-		expect( record[ pathName ]).toBe( 'value' );
+		expect( record[ pathName ] ).toBe( 'value' );
 	})
 
 	it( 'extends existing arrays', function(){

--- a/test-unit/unit/record/json-pathSpec.js
+++ b/test-unit/unit/record/json-pathSpec.js
@@ -139,12 +139,12 @@ describe( 'objects are created from paths and their value is set correctly', fun
 
 	it( 'even when the path is not NaNish and could be interpreted as a base 16 number', function() {
 		var record = {};
-    let pathName = '0x02335';
-    record = jsonPath.set( record, pathName, 'value' );
-    expect( record[ 0 ] ).toBe( undefined );
+		let pathName = '0x02335';
+		record = jsonPath.set( record, pathName, 'value' );
+		expect( record[ 0 ] ).toBe( undefined );
 		expect( record[ pathName] ).toBe( 'value' );
-    expect( jsonPath.get( record, pathName )).toBe( 'value' );
-    expect( record[ pathName ]).toBe( 'value' );
+		expect( jsonPath.get( record, pathName )).toBe( 'value' );
+		expect( record[ pathName ]).toBe( 'value' );
 	})
 
 	it( 'extends existing arrays', function(){


### PR DESCRIPTION
This is related to https://github.com/deepstreamIO/deepstream.io-client-js/issues/327
