### PR TITLE
update component-emitter

### DIFF
--- a/dist/deepstream.js
+++ b/dist/deepstream.js
@@ -1819,7 +1819,7 @@ module.exports = {
 },{}],10:[function(_dereq_,module,exports){
 var C = _dereq_( './constants/constants' ),
 	MS = _dereq_( './constants/merge-strategies' ),
-	Emitter = _dereq_( 'component-emitter' ),
+	Emitter = _dereq_( 'component-emitter2' ),
 	Connection = _dereq_( './message/connection' ),
 	EventHandler = _dereq_( './event/event-handler' ),
 	RpcHandler = _dereq_( './rpc/rpc-handler' ),
@@ -2319,7 +2319,7 @@ var messageBuilder = _dereq_( '../message/message-builder' ),
 	ResubscribeNotifier = _dereq_( '../utils/resubscribe-notifier' ),
 	C = _dereq_( '../constants/constants' ),
 	Listener = _dereq_( '../utils/listener' ),
-	EventEmitter = _dereq_( 'component-emitter' );
+	EventEmitter = _dereq_( 'component-emitter2' );
 
 /**
  * This class handles incoming and outgoing messages in relation
@@ -3326,7 +3326,7 @@ MessageParser.prototype._parseMessage = function( message, client ) {
 
 module.exports = new MessageParser();
 },{"../constants/constants":11}],18:[function(_dereq_,module,exports){
-var EventEmitter = _dereq_( 'component-emitter' ),
+var EventEmitter = _dereq_( 'component-emitter2' ),
 	C = _dereq_( '../constants/constants' ),
 	AckTimeoutRegistry = _dereq_( '../utils/ack-timeout-registry' ),
 	messageParser = _dereq_( '../message/message-parser' ),
@@ -3461,7 +3461,7 @@ PresenceHandler.prototype._resubscribe = function() {
 module.exports = PresenceHandler;
 },{"../constants/constants":11,"../message/message-builder":16,"../message/message-parser":17,"../utils/ack-timeout-registry":27,"../utils/resubscribe-notifier":29,"component-emitter":2}],19:[function(_dereq_,module,exports){
 var Record = _dereq_( './record' ),
-	EventEmitter = _dereq_( 'component-emitter' );
+	EventEmitter = _dereq_( 'component-emitter2' );
 
 /**
  * An AnonymousRecord is a record without a predefined name. It
@@ -3769,7 +3769,7 @@ function tokenize( path ) {
 };
 
 },{"../utils/utils":31}],21:[function(_dereq_,module,exports){
-var EventEmitter = _dereq_( 'component-emitter' ),
+var EventEmitter = _dereq_( 'component-emitter2' ),
 	Record = _dereq_( './record' ),
 	C = _dereq_( '../constants/constants' ),
 	ENTRY_ADDED_EVENT = 'entry-added',
@@ -4168,7 +4168,7 @@ var Record = _dereq_( './record' ),
 	SingleNotifier = _dereq_( '../utils/single-notifier' ),
 	C = _dereq_( '../constants/constants' ),
 	messageParser = _dereq_( '../message/message-parser' ),
-	EventEmitter = _dereq_( 'component-emitter' );
+	EventEmitter = _dereq_( 'component-emitter2' );
 
 /**
  * A collection of factories for records. This class
@@ -4502,7 +4502,7 @@ module.exports = RecordHandler;
 var jsonPath = _dereq_( './json-path' ),
 	utils = _dereq_( '../utils/utils' ),
 	ResubscribeNotifier = _dereq_( '../utils/resubscribe-notifier' ),
-	EventEmitter = _dereq_( 'component-emitter' ),
+	EventEmitter = _dereq_( 'component-emitter2' ),
 	C = _dereq_( '../constants/constants' ),
 	messageBuilder = _dereq_( '../message/message-builder' ),
 	messageParser = _dereq_( '../message/message-parser' );
@@ -5599,7 +5599,7 @@ Rpc.prototype._complete = function() {
 module.exports = Rpc;
 },{"../constants/constants":11,"../message/message-parser":17}],27:[function(_dereq_,module,exports){
 var C = _dereq_( '../constants/constants' ),
-	EventEmitter = _dereq_( 'component-emitter' );
+	EventEmitter = _dereq_( 'component-emitter2' );
 
 /**
  * Subscriptions to events are in a pending state until deepstream acknowledges

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "bufferutil": "^1.2.1",
-    "component-emitter": "1.1.2",
+    "component-emitter2": "^1.3.1",
     "utf-8-validate": "^1.2.1",
     "ws": "^1.1.1"
   },

--- a/src/client.js
+++ b/src/client.js
@@ -1,6 +1,6 @@
 var C = require( './constants/constants' ),
 	MS = require( './constants/merge-strategies' ),
-	Emitter = require( 'component-emitter' ),
+	Emitter = require( 'component-emitter2' ),
 	Connection = require( './message/connection' ),
 	EventHandler = require( './event/event-handler' ),
 	RpcHandler = require( './rpc/rpc-handler' ),

--- a/src/event/event-handler.js
+++ b/src/event/event-handler.js
@@ -4,7 +4,7 @@ var messageBuilder = require( '../message/message-builder' ),
 	ResubscribeNotifier = require( '../utils/resubscribe-notifier' ),
 	C = require( '../constants/constants' ),
 	Listener = require( '../utils/listener' ),
-	EventEmitter = require( 'component-emitter' );
+	EventEmitter = require( 'component-emitter2' );
 
 /**
  * This class handles incoming and outgoing messages in relation

--- a/src/presence/presence-handler.js
+++ b/src/presence/presence-handler.js
@@ -1,4 +1,4 @@
-var EventEmitter = require( 'component-emitter' ),
+var EventEmitter = require( 'component-emitter2' ),
 	C = require( '../constants/constants' ),
 	AckTimeoutRegistry = require( '../utils/ack-timeout-registry' ),
 	messageParser = require( '../message/message-parser' ),

--- a/src/record/anonymous-record.js
+++ b/src/record/anonymous-record.js
@@ -1,5 +1,5 @@
 var Record = require( './record' ),
-	EventEmitter = require( 'component-emitter' );
+	EventEmitter = require( 'component-emitter2' );
 
 /**
  * An AnonymousRecord is a record without a predefined name. It

--- a/src/record/list.js
+++ b/src/record/list.js
@@ -1,4 +1,4 @@
-var EventEmitter = require( 'component-emitter' ),
+var EventEmitter = require( 'component-emitter2' ),
 	Record = require( './record' ),
 	C = require( '../constants/constants' ),
 	ENTRY_ADDED_EVENT = 'entry-added',

--- a/src/record/record-handler.js
+++ b/src/record/record-handler.js
@@ -5,7 +5,7 @@ var Record = require( './record' ),
 	SingleNotifier = require( '../utils/single-notifier' ),
 	C = require( '../constants/constants' ),
 	messageParser = require( '../message/message-parser' ),
-	EventEmitter = require( 'component-emitter' );
+	EventEmitter = require( 'component-emitter2' );
 
 /**
  * A collection of factories for records. This class

--- a/src/record/record.js
+++ b/src/record/record.js
@@ -1,7 +1,7 @@
 var jsonPath = require( './json-path' ),
 	utils = require( '../utils/utils' ),
 	ResubscribeNotifier = require( '../utils/resubscribe-notifier' ),
-	EventEmitter = require( 'component-emitter' ),
+	EventEmitter = require( 'component-emitter2' ),
 	C = require( '../constants/constants' ),
 	messageBuilder = require( '../message/message-builder' ),
 	messageParser = require( '../message/message-parser' );
@@ -119,7 +119,7 @@ Record.prototype.set = function( pathOrData, dataOrCallback, callback ) {
 		if( ( typeof pathOrData === 'string' && pathOrData.length !== 0 ) && typeof dataOrCallback !== 'function' ) {
 			path = pathOrData;
 			data = dataOrCallback
-		} 
+		}
 		// set( data, callback )
 		else if( typeof pathOrData === 'object' && typeof dataOrCallback === 'function' ) {
 			data = pathOrData;
@@ -369,7 +369,7 @@ Record.prototype._recoverRecord = function( remoteVersion, remoteData, message )
 };
 
 Record.prototype._sendUpdate = function ( path, data, config ) {
-	this.version++; 
+	this.version++;
 	var msgData;
 	if( !path ) {
 		msgData = config === undefined ?
@@ -409,7 +409,7 @@ Record.prototype._onRecordRecovered = function( remoteVersion, remoteData, messa
 
 		var config = message.data[ 4 ];
 		if( config && JSON.parse( config ).writeSuccess ) {
-			var callback = this._writeCallbacks[ oldVersion ]; 
+			var callback = this._writeCallbacks[ oldVersion ];
 			delete this._writeCallbacks[ oldVersion ];
 			this._setUpCallback( this.version, callback )
 		}
@@ -545,12 +545,7 @@ Record.prototype._applyChange = function( newData ) {
 	var oldData = this._$data;
 	this._$data = newData;
 
-	if ( !this._eventEmitter._callbacks ) {
-		return;
-	}
-
-	var paths = Object.keys( this._eventEmitter._callbacks );
-
+	var paths = this._eventEmitter.eventNames();
 	for ( var i = 0; i < paths.length; i++ ) {
 		var newValue = jsonPath.get( newData, paths[ i ], false );
 		var oldValue = jsonPath.get( oldData, paths[ i ], false );

--- a/src/utils/ack-timeout-registry.js
+++ b/src/utils/ack-timeout-registry.js
@@ -1,5 +1,5 @@
 var C = require( '../constants/constants' ),
-	EventEmitter = require( 'component-emitter' );
+	EventEmitter = require( 'component-emitter2' );
 
 /**
  * Subscriptions to events are in a pending state until deepstream acknowledges

--- a/test-unit/mocks/client-mock.js
+++ b/test-unit/mocks/client-mock.js
@@ -1,4 +1,4 @@
-var Emitter = require( 'component-emitter' );
+var Emitter = require( 'component-emitter2' );
 
 var ClientMock = function() {
 	this.uid = 1;


### PR DESCRIPTION
component/emitter doesn't seem to be actively maintained anymore so I've made a fork.

https://www.npmjs.com/package/component-emitter2

Would like bring attention to the following commits relative to 1.1.2 which deepstream currently uses:

nxtedition/emitter@b34d74c
nxtedition/emitter@7aa9d9b

and

nxtedition/emitter@9baa392
nxtedition/emitter@2d1744a

Also, this fixes the "problem" of deepstream depending on the internal implementation by providing a `eventNames` method.