### PR TITLE
Fix #335: Set immediate callback fix for record.set

### DIFF
--- a/src/record/record.js
+++ b/src/record/record.js
@@ -119,7 +119,7 @@ Record.prototype.set = function( pathOrData, dataOrCallback, callback ) {
 		if( ( typeof pathOrData === 'string' && pathOrData.length !== 0 ) && typeof dataOrCallback !== 'function' ) {
 			path = pathOrData;
 			data = dataOrCallback
-		} 
+		}
 		// set( data, callback )
 		else if( typeof pathOrData === 'object' && typeof dataOrCallback === 'function' ) {
 			data = pathOrData;
@@ -151,17 +151,18 @@ Record.prototype.set = function( pathOrData, dataOrCallback, callback ) {
 	var newValue = jsonPath.set( oldValue, path, data, this._options.recordDeepCopy );
 
 	if ( oldValue === newValue ) {
+		if ( typeof callback === 'function' ) utils.setImmediate( callback, null );
 		return this;
 	}
 
 	var config;
-	if( callback !== undefined ) {
+	if( typeof callback === 'function' ) {
 		config = {};
 		config.writeSuccess = true;
 		this._setUpCallback(this.version, callback)
 		var connectionState = this._client.getConnectionState();
 		if( connectionState === C.CONNECTION_STATE.CLOSED || connectionState === C.CONNECTION_STATE.RECONNECTING ) {
-			callback( 'Connection error: error updating record as connection was closed' );
+			utils.setImmediate( callback, new Error( 'Connection error: error updating record as connection was closed' ) );
 		}
 	}
 	this._sendUpdate( path, data, config );
@@ -369,7 +370,7 @@ Record.prototype._recoverRecord = function( remoteVersion, remoteData, message )
 };
 
 Record.prototype._sendUpdate = function ( path, data, config ) {
-	this.version++; 
+	this.version++;
 	var msgData;
 	if( !path ) {
 		msgData = config === undefined ?
@@ -409,7 +410,7 @@ Record.prototype._onRecordRecovered = function( remoteVersion, remoteData, messa
 
 		var config = message.data[ 4 ];
 		if( config && JSON.parse( config ).writeSuccess ) {
-			var callback = this._writeCallbacks[ oldVersion ]; 
+			var callback = this._writeCallbacks[ oldVersion ];
 			delete this._writeCallbacks[ oldVersion ];
 			this._setUpCallback( this.version, callback )
 		}

--- a/src/record/record.js
+++ b/src/record/record.js
@@ -151,7 +151,13 @@ Record.prototype.set = function( pathOrData, dataOrCallback, callback ) {
 	var newValue = jsonPath.set( oldValue, path, data, this._options.recordDeepCopy );
 
 	if ( oldValue === newValue ) {
-		if ( typeof callback === 'function' ) utils.setImmediate( callback, null );
+		if ( typeof callback === 'function' ) {
+			if (isConnected( this._client )) {
+				utils.setImmediate( callback, null );
+			} else {
+				utils.setImmediate( callback, 'Connection error: error updating record as connection was closed' );
+			}
+		}
 		return this;
 	}
 
@@ -160,15 +166,21 @@ Record.prototype.set = function( pathOrData, dataOrCallback, callback ) {
 		config = {};
 		config.writeSuccess = true;
 		this._setUpCallback(this.version, callback)
-		var connectionState = this._client.getConnectionState();
-		if( connectionState === C.CONNECTION_STATE.CLOSED || connectionState === C.CONNECTION_STATE.RECONNECTING ) {
+
+		if (!isConnected( this._client )) {
 			utils.setImmediate( callback, 'Connection error: error updating record as connection was closed' );
 		}
 	}
+
 	this._sendUpdate( path, data, config );
 	this._applyChange( newValue );
 	return this;
 };
+
+function isConnected( client ) {
+	var connectionState = client.getConnectionState();
+	return !( connectionState === C.CONNECTION_STATE.CLOSED || connectionState === C.CONNECTION_STATE.RECONNECTING );
+}
 
 /**
  * Subscribes to changes to the records dataset.

--- a/src/record/record.js
+++ b/src/record/record.js
@@ -162,7 +162,7 @@ Record.prototype.set = function( pathOrData, dataOrCallback, callback ) {
 		this._setUpCallback(this.version, callback)
 		var connectionState = this._client.getConnectionState();
 		if( connectionState === C.CONNECTION_STATE.CLOSED || connectionState === C.CONNECTION_STATE.RECONNECTING ) {
-			utils.setImmediate( callback, new Error( 'Connection error: error updating record as connection was closed' ) );
+			utils.setImmediate( callback, 'Connection error: error updating record as connection was closed' );
 		}
 	}
 	this._sendUpdate( path, data, config );

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -176,6 +176,22 @@ exports.setInterval = function( callback, intervalDuration ) {
 	}
 };
 
+
+/**
+ * This method is used to break up long running operations and run a callback function immediately
+ * after the browser has completed other operations such as events and display updates.
+ *
+ * @param {Function} callback        the function that will be called after the given time
+ * @param {...*}   param1, ..., paramN additional parameters which are passed through to the callback
+ *
+ * @public
+ */
+exports.setImmediate = typeof setImmediate === 'function' ? setImmediate : function() {
+	var args = Array.prototype.slice.call( arguments );
+	args.splice( 1, 0, 0 );
+	setTimeout.apply( this, args );
+};
+
 /**
  * Used to see if a protocol is specified within the url
  * @type {RegExp}

--- a/test-unit/unit/utils/utilsSpec.js
+++ b/test-unit/unit/utils/utilsSpec.js
@@ -186,3 +186,26 @@ describe( 'utils.parseUrl adds all missing parts of the url', function(){
 			.toBe( 'ws://localhost/deepstream?query=value#login' );
 	});
 });
+
+describe( 'utils.setImmediate', function(){
+	it( 'callbacks asynchronously as soon as possible', function( done ) {
+		var syncronous = false;
+
+		utils.setImmediate( function() {
+			expect( syncronous ).toBe( true );
+			done();
+		})
+
+		syncronous = true;
+	}, 100 );
+
+	it( 'callbacks with arguments', function( done ) {
+		utils.setImmediate( function( a, b, c, d ) {
+			expect( a ).toBe( 1 );
+			expect( b ).toBe( 2 );
+			expect( c ).toBe( 3 );
+			expect( d ).toBe( 4 );
+			done();
+		}, 1, 2, 3, 4 );
+	}, 100 );
+})


### PR DESCRIPTION
A more sophisticated fix for issue #335 instead of PR https://github.com/deepstreamIO/deepstream.io-client-js/pull/336, to use setImmediate instead of synchronously calling callback.

Added a setImmediate in utils that fallbacks to setTimeout(func, 0) if setImmediate is not supported. Also added two unit-tests.

The spec tests at https://github.com/deepstreamIO/deepstream.io-client-specs/pull/23 should still work with this fix.