### PR TITLE
fix: Invalid remote wins merge conflicts

### DIFF
--- a/src/message/connection.js
+++ b/src/message/connection.js
@@ -267,7 +267,7 @@ Connection.prototype._checkHeartBeat = function () {
     this._client._$onError(
       C.TOPIC.CONNECTION,
       C.EVENT.CONNECTION_ERROR,
-      'Two connections heartbeats missed successively')
+      'heartbeat not received in the last ' + heartBeatTolerance + ' milliseconds')
     this._endpoint.close()
   }
 }

--- a/test-unit/unit/message/connectionSpec.js
+++ b/test-unit/unit/message/connectionSpec.js
@@ -116,7 +116,7 @@ describe('connects - heartbeats', () => {
     setTimeout(() => {
       expect(connection._endpoint.lastSendMessage).toBe(null)
       expect(connection.getState()).toBe('CLOSED')
-      expect(clientMock.lastError).toEqual(['C', 'connectionError', 'Two connections heartbeats missed successively'])
+      expect(clientMock.lastError).toEqual(['C', 'connectionError', 'heartbeat not received in the last 100 milliseconds'])
       done()
     }, 200)
   })


### PR DESCRIPTION
When the strategy is remote wins and the content is identical, we expect that
the server version number is taken and no actual merge conflict occurs

Fixes #224