### PR TITLE
Client check to invalid update from being sent.

### DIFF
--- a/src/record/record.js
+++ b/src/record/record.js
@@ -150,6 +150,10 @@ Record.prototype.set = function (pathOrData, dataOrCallback, callback) {
     data = dataOrCallback
   }
 
+  if(!path && (data === null || typeof data !== 'object')) {
+      throw new Error('invalid arguments, scalar values cannot be set without path');
+  }
+
   if (this._checkDestroyed('set')) {
     return this
   }

--- a/test-unit/unit/record/record-setSpec.js
+++ b/test-unit/unit/record/record-setSpec.js
@@ -41,6 +41,18 @@ describe('setting values sends the right messages to the server', () => {
     expect(() => { record.set(undefined) }).toThrow()
   })
 
+  it('throws error for null record data', () => {
+    expect(() => { record.set(null) }).toThrow()
+  })
+
+  it('throws error for string record data', () => {
+    expect(() => { record.set('Some String') }).toThrow()
+  })
+
+  it('throws error for numeric record data', () => {
+    expect(() => { record.set(100.24) }).toThrow()
+  })
+
   it('sends update messages for entire data changes with callback', () => {
     record.set({ name: 'Alex' }, setCallback)
     expect(connection.lastSendMessage).toBe(msg('R|U|testRecord|4|{"name":"Alex"}|{"writeSuccess":true}+'))


### PR DESCRIPTION
This is the client check to prevent an invalid update from being sent and thus saving a round trip.

Related PR: https://github.com/deepstreamIO/deepstream.io/pull/608