### PR TITLE
Try to stringify message errors so socket errors keep their data.

### DIFF
--- a/src/message/connection.js
+++ b/src/message/connection.js
@@ -320,7 +320,11 @@ Connection.prototype._onError = function (error) {
     if (error.code === 'ECONNRESET' || error.code === 'ECONNREFUSED') {
       msg = `Can't connect! Deepstream server unreachable on ${this._originalUrl}`
     } else {
-      msg = error.toString()
+      try {
+        msg = JSON.stringify(error)
+      } catch(e) {
+        msg = error.toString()
+      }
     }
     this._client._$onError(C.TOPIC.CONNECTION, C.EVENT.CONNECTION_ERROR, msg)
   }, 1)


### PR DESCRIPTION
Socket errors are returned to the client as the string "[object Event]".