### PR TITLE
Feat: List methods with write acknowledgement

### DIFF
--- a/src/record/list.js
+++ b/src/record/list.js
@@ -78,10 +78,13 @@ List.prototype.isEmpty = function () {
 /**
  * Updates the list with a new set of entries
  *
- * @public
  * @param {Array} entries
+ * @param {Function} [callback]
+ *
+ * @public
+ * @returns {void}
  */
-List.prototype.setEntries = function (entries) {
+List.prototype.setEntries = function (entries, callback) {
   const errorMsg = 'entries must be an array of record names'
   let i
 
@@ -99,9 +102,37 @@ List.prototype.setEntries = function (entries) {
     this._queuedMethods.push(this.setEntries.bind(this, entries))
   } else {
     this._beforeChange()
-    this._record.set(entries)
+
+    if (callback) {
+      this._record.set(entries, callback)
+    } else {
+      this._record.set(entries)
+    }
+
     this._afterChange()
   }
+}
+
+/**
+ * Wrapper function around the list.setEntries that returns a promise
+ * if no callback is supplied.
+ *
+ * @param {Array} entries
+ * @param {Function} callback
+ *
+ * @public
+ * @returns {Promise|void} if a callback is omitted a Promise is returned
+ *                         with the result of the write
+ */
+List.prototype.setEntriesWithAck = function (entries, callback) {
+  if (callback) {
+    return this.setEntries(entries, callback)
+  }
+  return new Promise((resolve, reject) => {
+    this.setEntries(entries, error => (
+      error === null ? resolve() : reject(error)
+    ))
+  })
 }
 
 /**

--- a/src/record/list.js
+++ b/src/record/list.js
@@ -99,16 +99,14 @@ List.prototype.setEntries = function (entries, callback) {
   }
 
   if (this._record.isReady === false) {
-    this._queuedMethods.push(this.setEntries.bind(this, entries))
+    this._queuedMethods.push(this.setEntries.bind(this, entries, callback))
   } else {
     this._beforeChange()
-
     if (callback) {
       this._record.set(entries, callback)
     } else {
       this._record.set(entries)
     }
-
     this._afterChange()
   }
 }
@@ -154,7 +152,7 @@ List.prototype.removeEntry = function (entry, indexOrCallback, callback) {
   }
 
   if (this._record.isReady === false) {
-    this._queuedMethods.push(this.removeEntry.bind(this, entry, index))
+    this._queuedMethods.push(this.removeEntry.bind(this, entry, index, cb))
     return
   }
 
@@ -168,14 +166,13 @@ List.prototype.removeEntry = function (entry, indexOrCallback, callback) {
       entries.push(currentEntries[i])
     }
   }
-  this._beforeChange()
 
+  this._beforeChange()
   if (cb) {
     this._record.set(entries, cb)
   } else {
     this._record.set(entries)
   }
-
   this._afterChange()
 }
 
@@ -228,7 +225,7 @@ List.prototype.addEntry = function (entry, indexOrCallback, callback) {
   }
 
   if (this._record.isReady === false) {
-    this._queuedMethods.push(this.addEntry.bind(this, entry, index))
+    this._queuedMethods.push(this.addEntry.bind(this, entry, index, cb))
     return
   }
 
@@ -239,14 +236,13 @@ List.prototype.addEntry = function (entry, indexOrCallback, callback) {
   } else {
     entries.push(entry)
   }
-  this._beforeChange()
 
+  this._beforeChange()
   if (cb) {
     this._record.set(entries, cb)
   } else {
     this._record.set(entries)
   }
-
   this._afterChange()
 }
 

--- a/src/record/list.js
+++ b/src/record/list.js
@@ -169,14 +169,22 @@ List.prototype.removeEntry = function (entry, index) {
  * Adds an entry to the list
  *
  * @param {String} entry
- * @param {Number} [index]
+ * @param {Number|Function} [indexOrCallback]
+ * @param {Function} [callback]
  *
  * @public
  * @returns {void}
  */
-List.prototype.addEntry = function (entry, index) {
+List.prototype.addEntry = function (entry, indexOrCallback, callback) {
   if (typeof entry !== 'string') {
     throw new Error('Entry must be a recordName')
+  }
+
+  let index = indexOrCallback
+  let cb = callback
+  if (typeof indexOrCallback === 'function') {
+    cb = indexOrCallback
+    index = undefined
   }
 
   if (this._record.isReady === false) {
@@ -192,8 +200,40 @@ List.prototype.addEntry = function (entry, index) {
     entries.push(entry)
   }
   this._beforeChange()
-  this._record.set(entries)
+
+  if (cb) {
+    this._record.set(entries, cb)
+  } else {
+    this._record.set(entries)
+  }
+
   this._afterChange()
+}
+
+/**
+ * Wrapper function around the list.addEntry that returns a promise
+ * if no callback is supplied.
+ *
+ * @param {String} entry
+ * @param {Number|Function} [index]
+ * @param {Function} callback
+ *
+ * @public
+ * @returns {Promise|void} if a callback is omitted a Promise is returned
+ *                         with the result of the write
+ */
+List.prototype.addEntryWithAck = function (entry, indexOrCallback, callback) {
+  if (typeof indexOrCallback === 'number' && callback) {
+    return this.addEntry(entry, indexOrCallback, callback)
+  }
+  if (typeof indexOrCallback === 'function') {
+    return this.addEntry(entry, indexOrCallback)
+  }
+  return new Promise((resolve, reject) => {
+    this.addEntry(entry, indexOrCallback, error => (
+      error === null ? resolve() : reject(error)
+    ))
+  })
 }
 
 /**

--- a/test-unit/unit/record/list-spec.js
+++ b/test-unit/unit/record/list-spec.js
@@ -161,4 +161,26 @@ describe('lists contain arrays of record names', () => {
     expect(promise instanceof Promise).toBe(true)
     expect(recordHandler._connection.lastSendMessage).toBe(msg('R|U|someList|23|["t","u","v","w","x","y"]|{"writeSuccess":true}+'))
   })
+
+  it('removes an entry from the list with a callback', () => {
+    expect(list.removeEntryWithAck('x', setCallback)).toBeUndefined()
+    expect(recordHandler._connection.lastSendMessage).toBe(msg('R|U|someList|24|["t","u","v","w","y"]|{"writeSuccess":true}+'))
+  })
+
+  it('removes an entry from the list with a promise', () => {
+    const promise = list.removeEntryWithAck('y')
+    expect(promise instanceof Promise).toBe(true)
+    expect(recordHandler._connection.lastSendMessage).toBe(msg('R|U|someList|25|["t","u","v","w"]|{"writeSuccess":true}+'))
+  })
+
+  it('removes an entry from the list on an explicit index with a callback', () => {
+    expect(list.removeEntryWithAck('t', 0, setCallback)).toBeUndefined()
+    expect(recordHandler._connection.lastSendMessage).toBe(msg('R|U|someList|26|["u","v","w"]|{"writeSuccess":true}+'))
+  })
+
+  it('removes an entry from the list on an explicit index with a promise', () => {
+    const promise = list.removeEntryWithAck('w', 2)
+    expect(promise instanceof Promise).toBe(true)
+    expect(recordHandler._connection.lastSendMessage).toBe(msg('R|U|someList|27|["u","v"]|{"writeSuccess":true}+'))
+  })
 })

--- a/test-unit/unit/record/list-spec.js
+++ b/test-unit/unit/record/list-spec.js
@@ -139,4 +139,26 @@ describe('lists contain arrays of record names', () => {
     expect(promise instanceof Promise).toBe(true)
     expect(recordHandler._connection.lastSendMessage).toBe(msg('R|U|someList|19|["v","w"]|{"writeSuccess":true}+'))
   })
+
+  it('adds an entry to the end of list with a callback', () => {
+    expect(list.addEntryWithAck('x', setCallback)).toBeUndefined()
+    expect(recordHandler._connection.lastSendMessage).toBe(msg('R|U|someList|20|["v","w","x"]|{"writeSuccess":true}+'))
+  })
+
+  it('adds an entry to the end of list with a promise', () => {
+    const promise = list.addEntryWithAck('y')
+    expect(promise instanceof Promise).toBe(true)
+    expect(recordHandler._connection.lastSendMessage).toBe(msg('R|U|someList|21|["v","w","x","y"]|{"writeSuccess":true}+'))
+  })
+
+  it('adds an entry to the list on an explicit index with a callback', () => {
+    expect(list.addEntryWithAck('u', 0, setCallback)).toBeUndefined()
+    expect(recordHandler._connection.lastSendMessage).toBe(msg('R|U|someList|22|["u","v","w","x","y"]|{"writeSuccess":true}+'))
+  })
+
+  it('adds an entry to the list at an explicit index with promise', () => {
+    const promise = list.addEntryWithAck('t', 0)
+    expect(promise instanceof Promise).toBe(true)
+    expect(recordHandler._connection.lastSendMessage).toBe(msg('R|U|someList|23|["t","u","v","w","x","y"]|{"writeSuccess":true}+'))
+  })
 })


### PR DESCRIPTION
- extends `setEntries`, `addEntry` & `removeEntry` methods with callback argument which is passed to `record.set`
- adds new promisifed methods: `setEntriesWithAck`, `addEntryWithAck` & `removeEntryWithAck`

See: https://github.com/deepstreamIO/deepstream.io/issues/830