### PR TITLE
Webpack: frontend bundle sockets, deepstream named export

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -6,6 +6,12 @@ module.exports = {
   output: {
     path: __dirname,
     filename: './dist/deepstream.js',
+    library: 'deepstream',
+    libraryTarget: 'umd',
+    umdNamedDefine: true
+  },
+  externals: {
+    "ws": "WebSocket"
   },
   resolve: {
     extensions: ['.js', '.ts'],
@@ -16,6 +22,6 @@ module.exports = {
     }],
   },
   plugins: [
-    new webpack.IgnorePlugin(/ws/),
+    // new webpack.IgnorePlugin(/ws/),
   ],
 };

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -6,6 +6,9 @@ module.exports = {
   output: {
     path: __dirname,
     filename: './dist/deepstream.min.js',
+    library: 'deepstream',
+    libraryTarget: 'umd',
+    umdNamedDefine: true
   },
   resolve: {
     extensions: ['.js', '.ts'],


### PR DESCRIPTION
It seems that when we try to use `WebSocket` as our frontend `ws` library the following error happens:

![screenshot from 2017-11-10 11-56-46](https://user-images.githubusercontent.com/13497307/32657900-70c157ee-c60f-11e7-89a1-53576a186fb2.png)

We should use a proper default socket library for frontend in case whoever is using our bundle does not feel like using his own socket factory

This pr should be merged when the frontend bundle is 100% ready