### PR TITLE
Add discard function to List

### DIFF
--- a/src/record/list.ts
+++ b/src/record/list.ts
@@ -42,6 +42,10 @@ export class List extends Emitter {
         return this.record.whenReady(this, callback)
     }
 
+    public discard (): void {
+      return this.record.discard()
+    }
+
     /**
      * Returns the array of list entries or an
      * empty array if the list hasn't been populated yet.


### PR DESCRIPTION
Seems like `List` is missing a discard function in DS4. As far as I could see in DS3, lists are basically wrappers for records? As far as I could tell DS3 only set an internal flag (which is no longer there) apart from discarding the record.