### PR TITLE
fix: DeepstreamClient.login() overload signature is incorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
+## [5.0.5] - 2019.11.21
 
+### Fix
+
+Method signature for the `DeepstreamClient.login()` overload that takes only a callback was incorrect
 
 ## [5.0.4] - 2019.11.03
 

--- a/src/deepstream-client.ts
+++ b/src/deepstream-client.ts
@@ -105,7 +105,7 @@ class DeepstreamClient extends Emitter {
   }
 
   public login (): Promise<JSONObject>
-  public login (callback: JSONObject): void
+  public login (callback: AuthenticationCallback): void
   public login (details: JSONObject): Promise<JSONObject>
   public login (details: JSONObject, callback: AuthenticationCallback): void
   public login (detailsOrCallback?: JSONObject | AuthenticationCallback, callback?: AuthenticationCallback): void | Promise<JSONObject | null> {


### PR DESCRIPTION
The overload signature for `login()` was incorrect, causing the following statement to not work as expected:
```
const client = new DeepstreamClient('localhost:6020')
await client.login({ username: 'foo' })
```
Second line yields
```
'await' has no effect on the type of this expression.ts(80007)
```
Because TypeScript resolves the overload that returns `void`.