### PR TITLE
Fix connection timeouts if server doesn't send something in time

### DIFF
--- a/src/connection/connection.spec.ts
+++ b/src/connection/connection.spec.ts
@@ -67,10 +67,10 @@ describe('connection', () => {
     await recieveConnectionClose()
   })
 
-  it('send pong when ping received across all states', async () => {
+  it('send ping and recieve pong across all states', async () => {
     await openConnection()
-    sendPong()
-    receivePing()
+    sendPing()
+    receivePong()
   })
 
   it('miss heartbeat once', async () => {
@@ -504,20 +504,20 @@ describe('connection', () => {
     await PromiseDelay(0)
   }
 
-  function receivePing () {
+  function receivePong () {
     socket.simulateMessages([{
       topic: TOPIC.CONNECTION,
-      action: CONNECTION_ACTION.PING
+      action: CONNECTION_ACTION.PONG
     }])
   }
 
-  function sendPong () {
+  function sendPing () {
     socketMock
       .expects('sendParsedMessage')
       .once()
       .withExactArgs({
         topic: TOPIC.CONNECTION,
-        action: CONNECTION_ACTION.PONG
+        action: CONNECTION_ACTION.PING
       })
   }
 

--- a/src/connection/socket-factory.ts
+++ b/src/connection/socket-factory.ts
@@ -35,8 +35,8 @@ export const socketFactory: SocketFactory = (url, options = { jsonTransportMode:
         socket.onparsedmessages(parseResults)
     }
     socket.getTimeSinceLastMessage = () => {
-        return 0
-        // return Date.now() - lastRecievedMessageTimestamp
+      if (lastRecievedMessageTimestamp < 0) return 0
+      return Date.now() - lastRecievedMessageTimestamp
     }
     socket.sendParsedMessage = (message: Message): void => {
         if (message.topic === TOPIC.CONNECTION && message.action === CONNECTION_ACTION.CLOSING) {

--- a/src/record/record-core.ts
+++ b/src/record/record-core.ts
@@ -551,6 +551,14 @@ export class RecordCore<Context = null> extends Emitter {
         this.services.timeoutRegistry.remove(actionMsg)
       }
 
+      // handle message denied on record set with ack
+      if (message.originalAction === RECORD_ACTION.PATCH) {
+        if (message.correlationId) {
+          this.recordServices.writeAckService.recieve(message)
+          return
+        }
+      }
+
       this.emit(EVENT.RECORD_ERROR, RECORD_ACTION[RECORD_ACTION.MESSAGE_DENIED], RECORD_ACTION[message.originalAction as number])
 
       if (message.originalAction === RECORD_ACTION.DELETE) {


### PR DESCRIPTION
This prevents the client from hanging when a user tries to write to a record with ack but he only has read access.