### PR TITLE
[fix] include url package as external dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5277,8 +5277,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -6966,7 +6965,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -6975,8 +6973,7 @@
         "punycode": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-          "dev": true
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@deepstream/protobuf": "^1.0.3",
     "protobufjs": "^6.9.0",
+    "url": "^0.11.0",
     "ws": "^7.3.0"
   },
   "browser": {

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -1,10 +1,4 @@
-let UniformResourceLocator: any
-
-if (typeof URL === 'undefined') {
-  UniformResourceLocator = require('url').URL
-} else {
-  UniformResourceLocator = URL
-}
+const urlParser: any = require('url')
 
 /**
  * Compares two objects for deep (recoursive) equality
@@ -98,13 +92,17 @@ export const parseUrl = (initialURl: string, defaultPath: string): string => {
   } else if (url.indexOf('//') === 0) {
     url = `ws:${url}`
   }
-  const serverUrl = new UniformResourceLocator(url)
+  const serverUrl = urlParser.parse(url)
+
   if (!serverUrl.host) {
-    throw new Error('invalid url, missing host')
+    throw new Error('Invalid URL: ws://')
   }
   serverUrl.protocol = serverUrl.protocol ? serverUrl.protocol : 'ws:'
-  serverUrl.pathname = serverUrl.pathname && serverUrl.pathname !== '/' ? serverUrl.pathname : defaultPath
-  return serverUrl.href
+  if (serverUrl.pathname === '/' && initialURl.charAt(initialURl.length - 1) !== '/') {
+     serverUrl.pathname = defaultPath
+   }
+   serverUrl.pathname = serverUrl.pathname ? serverUrl.pathname : defaultPath
+   return urlParser.format(serverUrl)
 }
 
 /**


### PR DESCRIPTION
Hi @yasserf, hope everything is ok.

This is actually needed for the client to work in react native. I basically recovered the code from [this pull request](https://github.com/deepstreamIO/deepstream.io-client-js/pull/517), added the missing package.json dependency, and ommited the change to `jsonTransportMode` since it just triggers a warning in react native.

I compared the bundle sizes:
with the url package: non-minified 550707 B / minified 189400 B
As is : non-minified 550703 B / minified 189375 B

The difference is negligeable in my opinion.

Let me know what you think and I can push the package and changelog changes.

Cheers