### PR TITLE
[task] do not depend on browser or nodejs URL api [fix] export DeepstreamClient as object property in bundle

### DIFF
--- a/src/connection/socket-factory.ts
+++ b/src/connection/socket-factory.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer'
 import { parse } from '@deepstream/protobuf/dist/src/message-parser'
 import { getMessage } from '@deepstream/protobuf/dist/src/message-builder'
 import {Socket} from '../deepstream-client'

--- a/src/deepstream.ts
+++ b/src/deepstream.ts
@@ -1,3 +1,3 @@
 import { DeepstreamClient } from './deepstream-client'
 
-export = DeepstreamClient
+export { DeepstreamClient }

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -1,11 +1,3 @@
-let UniformResourceLocator: any
-
-if (typeof URL === 'undefined') {
-  UniformResourceLocator = require('url').URL
-} else {
-  UniformResourceLocator = URL
-}
-
 /**
  * Compares two objects for deep (recoursive) equality
  *
@@ -98,13 +90,30 @@ export const parseUrl = (initialURl: string, defaultPath: string): string => {
   } else if (url.indexOf('//') === 0) {
     url = `ws:${url}`
   }
-  const serverUrl = new UniformResourceLocator(url)
-  if (!serverUrl.host) {
-    throw new Error('invalid url, missing host')
+
+  const protocol = url.split('//')[0]
+  let host = url.split('//')[1]
+
+  if (!host) {
+    throw new Error('Invalid URL: ws://')
   }
-  serverUrl.protocol = serverUrl.protocol ? serverUrl.protocol : 'ws:'
-  serverUrl.pathname = serverUrl.pathname && serverUrl.pathname !== '/' ? serverUrl.pathname : defaultPath
-  return serverUrl.href
+
+  let path = null
+  if (host.indexOf('/') > -1) {
+    path = host.split('/')
+    host = path.shift() || ''
+    path = '/' + path.join('')
+  } else {
+    if (host.indexOf('?') > -1) {
+      path = host.split('?')
+      host = path.shift() || ''
+      path = defaultPath + '?' + path.join('')
+    }
+  }
+
+  if (!path || path === '/') path = defaultPath
+
+  return `${protocol}//${host}${path}`
 }
 
 /**


### PR DESCRIPTION
Hi @yasserf, hope everything is ok.

I gave a second thought to the react-native issue and chose not to use the URL api, neither from the browser nor nodejs, since the use case is rather simple, and coded the url string manipulation directly. This allows to use the client in web, nodejs and react-native without adding more external dependencies. This fixes #515

Also exported the client as object in order to maintain the same api in the bundle. This fixes issue #528 

Let me know what you think and I can push the package and changelog updates.

Also, should the main file in the package.json point to the bundle?

Cheers