### PR TITLE
[task] implement client reset function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepstream/client",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepstream/client",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "description": "the javascript client for deepstream.io",
   "keywords": [
     "deepstream",
@@ -8,7 +8,7 @@
     "realtime",
     "client"
   ],
-  "main": "dist/src/deepstream-client.js",
+  "main": "dist/bundle/ds.min.js",
   "types": "dist/src/deepstream-client.d.ts",
   "directories": {
     "test": "src/test"


### PR DESCRIPTION
Hi @yasserf !

I encountered the following issue while using the v5 client:

- After closing the connection I wasn't able to connect again. For example if I'm on an app and then someone else want's to use it, I wasn't able to logout and then login with other credentials (neither the same credentials). On the web is not such an issue because you reload the page and that's it, but on react-native it's not that simple.

- Looking at the code I realised that the close method closes all services, including connection, thus making impossible to reconnect under the same instance of the client. That's why I chose to extract the main part of the client constructor to another function (called reset) which is called upon creating a new instance of the client and is also available to be called as a client method, but under this scenario it will only work if the connection status is `CLOSING` or `CLOSED`, that is only to actually reset the client after closing it.

Let me know what you think, I'm not so confident on my typescript code, but it passes all the tests and linter.

Best
