### PR TITLE
[fix] discard all references of the record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [5.1.5] - 2020.08.18
+
+### Fix  
+
+- Discard all references of a record when calling `.discard()`
+- Remove subscriptions from record reference when calling `.unsubscribe()`
+
+## [5.1.4] - 2020.07.29
+
+### Chore  
+
+- Bump dependencies
+
 ## [5.1.3] - 2020.07.14
 
 ### Fix

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepstream/client",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepstream/client",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "description": "the javascript client for deepstream.io",
   "keywords": [
     "deepstream",

--- a/src/record/record-core.ts
+++ b/src/record/record-core.ts
@@ -117,6 +117,13 @@ export class RecordCore<Context = null> extends Emitter {
   })
 }
 
+  /**
+  * Removes scope from emitter
+  */
+  public removeContext (ref: any): void {
+    this.emitter.removeContext(ref)
+  }
+
   private onDirtyServiceLoaded () {
     this.services.storage.get(this.name, (recordName, version, data) => {
       this.services.connection.onReestablished(this.onConnectionReestablished)

--- a/src/record/record.ts
+++ b/src/record/record.ts
@@ -101,12 +101,14 @@ export class Record extends Emitter  {
 
     public unsubscribe (path: string, callback: (data: any) => void): void {
         const parameters = utils.normalizeArguments(arguments)
-        this.subscriptions = this.subscriptions.filter(subscription => {
-            return (
-                subscription.path !== parameters.path ||
-                subscription.callback !== parameters.callback
-            )
-        })
+        for (const item of this.record.references) {
+          item.subscriptions = item.subscriptions.filter((subscription: any) => {
+            if (!parameters.callback && (subscription.path === parameters.path)) return false
+            if (parameters.callback && (subscription.path === parameters.path && subscription.callback === parameters.callback)) return false
+            if (parameters.callback && subscription.callback === parameters.callback) return false
+            return true
+          })
+        }
 
         this.record.unsubscribe(parameters)
     }

--- a/src/record/record.ts
+++ b/src/record/record.ts
@@ -112,11 +112,13 @@ export class Record extends Emitter  {
     }
 
     public discard (): void {
-        for (let i = 0; i < this.subscriptions.length; i++) {
-            this.record.unsubscribe(this.subscriptions[i])
+      for (const item of this.record.references) {
+        for (let i = 0; i < item.subscriptions.length; i++) {
+          this.record.unsubscribe(item.subscriptions[i])
         }
-        this.record.removeReference(this)
-        this.record.removeContext(this)
+        this.record.removeReference(item)
+        this.record.removeContext(item)
+      }
     }
 
     public delete (callback?: (error: string | null) => void): void | Promise<void> {


### PR DESCRIPTION
I encountered the following issue: calling record.discard() for a record that has been retrieved multiple times does not actually discard all the record instances nor unsubscribes from them. Example:

```
const { Deepstream } = require('@deepstream/server')
const { DeepstreamClient } = require('@deepstream/client')

const run = async () => {
  const server = new Deepstream({})
  server.start()

  server.on('error', (e) => {
    console.error(e)
  })

  server.on('started', () => {
    console.log('Started')
    const client = new DeepstreamClient('localhost:6020')
    client.login(() => {
      client.record.getRecord('user').whenReady((record) => {
       // log data changes
        record.subscribe((data) => {
          console.log('subscribed data', data)
        })
       // this should be logged
        record.set('one', 1)

       // this is called after the timeout a few lines below
        setTimeout(function () {
          console.log('end')
          // this should not trigger the subscription log
          record.set('three', 3)
        }, 10 * 1000)
      })

      setTimeout(function () {
        client.record.getRecord('user').whenReady((record) => {
         // this should be logged
          record.set('two', 2)
          // record.unsubscribe()
          record.discard()
        })
      }, 5 * 1000)
    })
  })
}

run()
```
After calling record.discard() the subscribed data is still logged.

If you replace discard for unsubscribe, the subscription is actually removed and there will be no final log, although the record will still be present on the client.

The commit fixes this behaviour, so all instances of the record are unsubscribed and removed from the client. I imagine this is the expected behaviour.

Let me know what you think in order to push version bump and changelog.