### PR TITLE
fix: provide context for record subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [5.1.6] - 2020.09.04
+
+### Fix  
+
+- Undo last changes to  `discard()` and `unsubscribe()` logic. Those operations only affect the current record instances, not all instances of the record in the client.
+- provide context for record subscriptions
+- Fix emitter logic
+
 ## [5.1.5] - 2020.08.18
 
 ### Fix  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepstream/client",
-  "version": "5.1.5",
+  "version": "5.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepstream/client",
-  "version": "5.1.5",
+  "version": "5.1.6",
   "description": "the javascript client for deepstream.io",
   "keywords": [
     "deepstream",

--- a/src/record/anonymous-record.ts
+++ b/src/record/anonymous-record.ts
@@ -61,7 +61,7 @@ export class AnonymousRecord extends Emitter  {
         this.record.addReference(this)
 
         for (let i = 0; i < this.subscriptions.length; i++) {
-          this.record.subscribe(this.subscriptions[i])
+          this.record.subscribe(this.subscriptions[i], this)
         }
 
         this.emit('nameChanged', recordName)
@@ -109,7 +109,7 @@ export class AnonymousRecord extends Emitter  {
         const parameters = utils.normalizeArguments(arguments)
         this.subscriptions.push(parameters)
         if (this.record) {
-            this.record.subscribe(parameters)
+            this.record.subscribe(parameters, this)
         }
     }
 
@@ -117,21 +117,20 @@ export class AnonymousRecord extends Emitter  {
         const parameters = utils.normalizeArguments(arguments)
 
         this.subscriptions = this.subscriptions.filter(subscription => {
-            return (
-                subscription.path !== parameters.path ||
-                subscription.callback !== parameters.callback
-            )
+          if (!parameters.callback && (subscription.path === parameters.path)) return false
+          if (parameters.callback && (subscription.path === parameters.path && subscription.callback === parameters.callback)) return false
+          return true
         })
 
         if (this.record) {
-            this.record.unsubscribe(parameters)
+            this.record.unsubscribe(parameters, this)
         }
     }
 
     public discard (): void {
         if (this.record) {
             for (let i = 0; i < this.subscriptions.length; i++) {
-                this.record.unsubscribe(this.subscriptions[i])
+                this.record.unsubscribe(this.subscriptions[i], this)
             }
             return this.record.removeReference(this)
         }

--- a/src/record/list.ts
+++ b/src/record/list.ts
@@ -196,7 +196,7 @@ export class List extends Emitter {
         parameters.callback = listCallback
 
         this.subscriptions.push(parameters)
-        this.record.subscribe(parameters)
+        this.record.subscribe(parameters, this)
     }
 
     /**
@@ -212,8 +212,13 @@ export class List extends Emitter {
 
         const listenCallback = this.wrappedFunctions.get(parameters.callback)
         parameters.callback = listenCallback as (data: any) => void
-        this.record.unsubscribe(parameters)
         this.wrappedFunctions.delete(parameters.callback)
+        this.subscriptions = this.subscriptions.filter((subscription: any) => {
+          if (parameters.callback && parameters.callback !== subscription.callback) return true
+          return false
+        })
+
+        this.record.unsubscribe(parameters, this)
     }
 
 /**
@@ -340,7 +345,7 @@ private applyUpdate  (message: RecordMessage) {
 
   private destroy () {
     for (let i = 0; i < this.subscriptions.length; i++) {
-      this.record.unsubscribe(this.subscriptions[i])
+      this.record.unsubscribe(this.subscriptions[i], this)
     }
     this.wrappedFunctions.clear()
     this.record.removeContext(this)

--- a/src/record/record-core.ts
+++ b/src/record/record-core.ts
@@ -117,13 +117,6 @@ export class RecordCore<Context = null> extends Emitter {
   })
 }
 
-  /**
-  * Removes scope from emitter
-  */
-  public removeContext (ref: any): void {
-    this.emitter.removeContext(ref)
-  }
-
   private onDirtyServiceLoaded () {
     this.services.storage.get(this.name, (recordName, version, data) => {
       this.services.connection.onReestablished(this.onConnectionReestablished)
@@ -291,7 +284,7 @@ export class RecordCore<Context = null> extends Emitter {
  * If called with true for triggerNow, the callback will
  * be called immediatly with the current value
  */
-  public subscribe (args: utils.RecordSubscribeArguments) {
+  public subscribe (args: utils.RecordSubscribeArguments, context?: any) {
     if (args.path !== undefined && (typeof args.path !== 'string' || args.path.length === 0)) {
       throw new Error('invalid argument path')
     }
@@ -305,11 +298,11 @@ export class RecordCore<Context = null> extends Emitter {
 
     if (args.triggerNow) {
       this.whenReadyInternal(null, () => {
-        this.emitter.on(args.path || '', args.callback)
+        this.emitter.on(args.path || '', args.callback, context)
         args.callback(this.get(args.path))
       })
     } else {
-      this.emitter.on(args.path || '', args.callback)
+      this.emitter.on(args.path || '', args.callback, context)
     }
   }
 
@@ -328,7 +321,7 @@ export class RecordCore<Context = null> extends Emitter {
    *                                          method was passed to subscribe, the same method
    *                                          must be passed to unsubscribe as well.
    */
-  public unsubscribe (args: utils.RecordSubscribeArguments) {
+  public unsubscribe (args: utils.RecordSubscribeArguments, context?: any) {
     if (args.path !== undefined && (typeof args.path !== 'string' || args.path.length === 0)) {
       throw new Error('invalid argument path')
     }
@@ -340,7 +333,7 @@ export class RecordCore<Context = null> extends Emitter {
       return
     }
 
-    this.emitter.off(args.path || '', args.callback)
+    this.emitter.off(args.path || '', args.callback, context)
   }
 
   /**

--- a/src/record/record.ts
+++ b/src/record/record.ts
@@ -96,31 +96,26 @@ export class Record extends Emitter  {
     public subscribe (path: string, callback: (data: any) => void, triggerNow?: boolean) {
         const parameters = utils.normalizeArguments(arguments)
         this.subscriptions.push(parameters)
-        this.record.subscribe(parameters)
+        this.record.subscribe(parameters, this)
     }
 
     public unsubscribe (path: string, callback: (data: any) => void): void {
         const parameters = utils.normalizeArguments(arguments)
-        for (const item of this.record.references) {
-          item.subscriptions = item.subscriptions.filter((subscription: any) => {
-            if (!parameters.callback && (subscription.path === parameters.path)) return false
-            if (parameters.callback && (subscription.path === parameters.path && subscription.callback === parameters.callback)) return false
-            if (parameters.callback && subscription.callback === parameters.callback) return false
-            return true
-          })
-        }
+        this.subscriptions = this.subscriptions.filter((subscription: any) => {
+          if (!parameters.callback && (subscription.path === parameters.path)) return false
+          if (parameters.callback && (subscription.path === parameters.path && subscription.callback === parameters.callback)) return false
+          return true
+        })
 
-        this.record.unsubscribe(parameters)
+        this.record.unsubscribe(parameters, this)
     }
 
     public discard (): void {
-      for (const item of this.record.references) {
-        for (let i = 0; i < item.subscriptions.length; i++) {
-          this.record.unsubscribe(item.subscriptions[i])
+        for (let i = 0; i < this.subscriptions.length; i++) {
+            this.record.unsubscribe(this.subscriptions[i], this)
         }
-        this.record.removeReference(item)
-        this.record.removeContext(item)
-      }
+        this.record.removeReference(this)
+        this.record.removeContext(this)
     }
 
     public delete (callback?: (error: string | null) => void): void | Promise<void> {

--- a/src/util/emitter.ts
+++ b/src/util/emitter.ts
@@ -42,7 +42,7 @@ export class Emitter {
     }
 
     // specific event
-    const callbacks = this.callbacks.get(event!)
+    let callbacks = this.callbacks.get(event!)
     if (!callbacks) {
         return this
     }
@@ -54,30 +54,26 @@ export class Emitter {
     }
 
     // remove specific handler
-    for (let i = 0; i < callbacks.length; i++) {
-      const { fn: cb, scope: context } = callbacks[i]
+    callbacks = callbacks.filter((item: any) => {
+      const { fn: cb, scope: context } = item
 
       // handle unsubscribing from all callbacks for a given record path
       if (event !== '' && fn === undefined && scope === context) {
-        callbacks.splice(i, 1)
-      }
-
-      // handle unsubscribing from all callbacks for a list
-      if (event === '' && fn === undefined && scope === context && scope.constructor.name === 'List') {
-        callbacks.splice(i, 1)
+        return false
       }
 
       if (cb === fn || (cb as any).fn === fn) {
         if (scope === undefined || scope === context) {
-          callbacks.splice(i, 1)
+          return false
         }
       }
-    }
+      return true
+    })
 
-    // Remove event specific arrays for event types that no
-    // one is subscribed for to avoid memory leak.
     if (callbacks.length === 0) {
         this.callbacks.delete(event!)
+    } else {
+        this.callbacks.set(event!, callbacks)
     }
 
     return this

--- a/src/util/emitter.ts
+++ b/src/util/emitter.ts
@@ -56,6 +56,17 @@ export class Emitter {
     // remove specific handler
     for (let i = 0; i < callbacks.length; i++) {
       const { fn: cb, scope: context } = callbacks[i]
+
+      // handle unsubscribing from all callbacks for a given record path
+      if (event !== '' && fn === undefined && scope === context) {
+        callbacks.splice(i, 1)
+      }
+
+      // handle unsubscribing from all callbacks for a list
+      if (event === '' && fn === undefined && scope === context && scope.constructor.name === 'List') {
+        callbacks.splice(i, 1)
+      }
+
       if (cb === fn || (cb as any).fn === fn) {
         if (scope === undefined || scope === context) {
           callbacks.splice(i, 1)


### PR DESCRIPTION
This should fix the problems with unsubscribing from a record and keeping other record's subscriptions active.
I had to put a couple more conditions on the emitter file open for review.

The previous pull request was closed to the history rewrite (a bad choice)