### PR TITLE
fix: remove callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [5.1.7] - 2020.09.10
+
+### Fix  
+
+- Remove callback after calling single notifier with error. This was preventing future messages from being sent after reconnection.
+
 ## [5.1.6] - 2020.09.04
 
 ### Fix  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepstream/client",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepstream/client",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "description": "the javascript client for deepstream.io",
   "keywords": [
     "deepstream",

--- a/src/record/single-notifier.ts
+++ b/src/record/single-notifier.ts
@@ -55,6 +55,7 @@ export class SingleNotifier<MessageType extends Message> {
     } else if (this.services.connection.isInLimbo) {
       this.limboQueue.push(message)
     } else {
+      this.requests.delete(name)
       callback(EVENT.CLIENT_OFFLINE)
     }
   }


### PR DESCRIPTION
Adding a notifier when offline called the callback inmediately, but it wasn't removed from the requests object, adn therefore future calls would not send the message