### PR TITLE
change bundle file for react-native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [5.1.8] - 2020.09.17
+
+### Fix  
+
+- React-native post install script must point to non-minified bundle.
+
 ## [5.1.7] - 2020.09.10
 
 ### Fix  

--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ Make sure the `src/client.d.ts` file is accessible to the Typescript compiler. D
 
 ## Install in react-native  
 
-For usage in react-native the bundled client available at `dist/bundle/ds.min.js` must be used. In order to automatically change the main file in package.json to the bundle file install as: `DEEPSTREAM_ENV=react-native npm install @deepstream/client`.  
+For usage in react-native the bundled client available at `dist/bundle/ds.js` must be used. In order to automatically change the main file in package.json to the bundle file install as: `DEEPSTREAM_ENV=react-native npm install @deepstream/client`. Also the metro bundler must be configured. Check the [documentation](https://deepstream.io/tutorials/integrations/mobile/reactnative/) for more details

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepstream/client",
-  "version": "5.1.7",
+  "version": "5.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepstream/client",
-  "version": "5.1.7",
+  "version": "5.1.8",
   "description": "the javascript client for deepstream.io",
   "keywords": [
     "deepstream",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -5,7 +5,7 @@ if (deepstreamEnv !== 'react-native') {
 }
 
 const saveFile = require('fs').writeFileSync
-const reactNativeMainPath = 'dist/bundle/ds.min.js'
+const reactNativeMainPath = 'dist/bundle/ds.js'
 
 const basePath = require.main.filename.split('scripts/postinstall')[0]
 const pkgJsonPath =  basePath + 'package.json'


### PR DESCRIPTION
When building the react native app for production, the minified client file does not compile correctly for react-native's javascript engine. Therefore the non minified bundle must be used and if a minifier is used for building the react-native app, some configuration options must be set that will be described in the website docs.