### PR TITLE
BUGFIX: postinstall: changed basePath resolution to work on windows

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const deepstreamEnv = process.env.DEEPSTREAM_ENV
 
 if (deepstreamEnv !== 'react-native') {
@@ -7,9 +9,9 @@ if (deepstreamEnv !== 'react-native') {
 const saveFile = require('fs').writeFileSync
 const reactNativeMainPath = 'dist/bundle/ds.js'
 
-const basePath = require.main.filename.split('scripts/postinstall')[0]
-const pkgJsonPath =  basePath + 'package.json'
-const pkgJsonPathDist = basePath + 'dist/package.json'
+const basePath = path.normalize(path.join(__dirname, '..'))
+const pkgJsonPath = path.join(basePath, 'package.json')
+const pkgJsonPathDist = path.join(basePath, 'dist', 'package.json')
 
 const json = require(pkgJsonPath)
 const jsonDist = require(pkgJsonPathDist)


### PR DESCRIPTION
BUGFIX

# Brief 
When installing `@deepstream/client` in `react-native` project on Windows 10 error occurs in `scripts/postinstall.js`.

# Detail
Powershell command:
```ps
$env:DEEPSTREAM_ENV = "react-native"
yarn add @deepstream/client
```

Error from output
```
Command: node scripts/postinstall.js
Arguments:
Directory: C:\MY_PROJECT\node_modules\@deepstream\client
Output:
internal/modules/cjs/loader.js:638
    throw err;
    ^
Error: Cannot find module 'C:\MY_PROJECT\node_modules\@deepstream\client\scripts\postinstall.jspackage.json'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Module.require (internal/modules/cjs/loader.js:692:17)
```

As you can see, script tries to include `postinstall.jspackage.json` file. This was caused by:
```javascript
const basePath = require.main.filename.split('scripts/postinstall')[0]
```
This approach works only if path is returned with forward slashes as separators. This is not the case on WIndows.

# Solution (this PR)
Using `__dirname` and `path` node library (built in) which is system-agnostic way of parsing paths.
