### PR TITLE
fix: send ping message based on lastSentMessage timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [5.1.11] - 2020.12.1
+
+### Fix
+
+- Send heartbeat packets according to `lastSentMessageTimestamp`, not `lastRecievedMessageTimestamp`.
+
 ## [5.1.10] - 2020.09.24
 
 ### Fix  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepstream/client",
-  "version": "5.1.10",
+  "version": "5.1.11",
   "description": "the javascript client for deepstream.io",
   "keywords": [
     "deepstream",

--- a/src/connection/socket-factory.ts
+++ b/src/connection/socket-factory.ts
@@ -21,6 +21,7 @@ export const socketFactory: SocketFactory = (url, options = { jsonTransportMode:
     const pingMessage = buildMessage({ topic: TOPIC.CONNECTION, action: CONNECTION_ACTION.PING }, false)
     let pingInterval: number | null = null
     let lastRecievedMessageTimestamp = -1
+    let lastSentMessageTimestamp = -1
 
     // tslint:disable-next-line:no-empty
     socket.onparsedmessage = () => {}
@@ -54,6 +55,7 @@ export const socketFactory: SocketFactory = (url, options = { jsonTransportMode:
             delete message.data
         }
         socket.send(buildMessage(message, false))
+        lastSentMessageTimestamp = Date.now()
     }
 
     socket.onclosed = null
@@ -65,9 +67,10 @@ export const socketFactory: SocketFactory = (url, options = { jsonTransportMode:
     socket.onopened = null
     socket.onopen = () => {
         pingInterval = setInterval(() => {
-            if (Date.now() - lastRecievedMessageTimestamp > heartBeatInterval) {
+            if (Date.now() - lastSentMessageTimestamp > heartBeatInterval) {
                 try {
                     socket.send(pingMessage)
+                    lastSentMessageTimestamp = Date.now()
                 } catch (e) {
                     clearTimeout(pingInterval!)
                 }


### PR DESCRIPTION
On the client side, the original logic is that its checks if a message wasn't received for a `heartbeatInterval` and decide to send a ping. But if the client only just subscribes to the change of server data and not publish any message, the time interval of server data change is always less than `heartBeatInterval`, the client will not send any Ping, so the server will not receive any data from the client, and the client will be considered disconnected.

Change `lastRecievedMessageTimestamp` to `lastSentMessageTimestamp`, which can ensure that the client sends a message to the server at least once in a `heartbeatInterval `.