### PR TITLE
Error when running under vue3 / vite

### DIFF
--- a/src/connection/socket-factory.ts
+++ b/src/connection/socket-factory.ts
@@ -3,7 +3,7 @@ import { getMessage } from '@deepstream/protobuf/dist/src/message-builder'
 import {Socket} from '../deepstream-client'
 import { JSONObject, TOPIC, Message, CONNECTION_ACTION } from '../constants'
 
-const global = window
+const global = global || window
 const BrowserWebsocket = (global.WebSocket || global.MozWebSocket) as any
 
 export type SocketFactory = (url: string, options: JSONObject, heartBeatInterval: number) => Socket

--- a/src/connection/socket-factory.ts
+++ b/src/connection/socket-factory.ts
@@ -3,6 +3,7 @@ import { getMessage } from '@deepstream/protobuf/dist/src/message-builder'
 import {Socket} from '../deepstream-client'
 import { JSONObject, TOPIC, Message, CONNECTION_ACTION } from '../constants'
 
+const global = window
 const BrowserWebsocket = (global.WebSocket || global.MozWebSocket) as any
 
 export type SocketFactory = (url: string, options: JSONObject, heartBeatInterval: number) => Socket


### PR DESCRIPTION
"global" is not valid in client-side code.  Here is one proposed patch that gets things working, but possibly a different refactor makes more sense.