### PR TITLE
Fix: Version conflict when receiving 'PATCH' action causes record to go into 'MERGING' state indefinitely

### DIFF
--- a/src/record/record-core.ts
+++ b/src/record/record-core.ts
@@ -719,6 +719,7 @@ export class RecordCore<Context = null> extends Emitter {
         * the full state of the record
         **/
         this.sendRead()
+        this.recordServices.readRegistry.register(this.name, this, this.handleReadResponse)
       } else {
         this.recoverRecordFromMessage(message)
       }


### PR DESCRIPTION
I had a producer which frequently updated a record using the "patch" operation (i.e. setting only one property of the record). I noticed that occasionally my subscribers stopped handling updates.

Through debugging I found that when the subscriber stopped handling updates, the record would go into "MERGING" state and then never leave that state. After further debugging, I think that the cause for this is that the record issues a "read" request but forgets to register a callback. Thus, the read response is not handled and the record never leaves the "MERGING" state.

Properly registering the callback for the read request seems to fix the problem I was experiencing.